### PR TITLE
DEP: remove scipy as a dependency

### DIFF
--- a/docs/source/i_get_started.rst
+++ b/docs/source/i_get_started.rst
@@ -53,10 +53,6 @@ environment.
      - 3.6.3
      - 3.5.1
      - (used for plotting curves)
-   * - SciPy
-     - 1.9.3
-     - 1.8.0
-     - (used for `brentq` algorithm in bond yield solving)
 
 
 Introduction to Rateslib

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -120,8 +120,8 @@ capturing aspects like trading calendars, day count conventions, payment delays,
             <div id="collapseFourA" class="collapse" data-parent="#accordion">
                 <div class="card-body">
 
-The dependencies are to **NumPy**, **Pandas**, **Matplotlib** and (to a very minor
-degree) **SciPy**. *Rateslib* does not have any dependencies to any automatic
+The dependencies are to **NumPy**, **Pandas**, and **Matplotlib**. *Rateslib* does
+not have any dependencies to any automatic
 differentiation libraries, such as PyAudi or JAX, preferring initially to use its
 own forward mode module.
 

--- a/minimum_requirements.txt
+++ b/minimum_requirements.txt
@@ -2,7 +2,6 @@
 # Python 3.9
 numpy==1.21.5
 pandas==1.4.1
-scipy==1.8.0
 matplotlib==3.5.1
 
 # development

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ license = { file = "LICENSE" }
 keywords = ["interest rate", "derivatives", "swaps", "bonds", "fixed income"]
 dependencies = [
     "numpy>=1.21.5",
-    "scipy>=1.8.0",
     "matplotlib>=3.5.1",
     "pandas>=1.4.1",
 ]

--- a/rateslib/__init__.py
+++ b/rateslib/__init__.py
@@ -1,7 +1,7 @@
 __docformat__ = "restructuredtext"
 
 # Let users know if they're missing any of our hard dependencies
-_hard_dependencies = ("pandas", "scipy", "matplotlib", "numpy")
+_hard_dependencies = ("pandas", "matplotlib", "numpy")
 _missing_dependencies = []
 
 for _dependency in _hard_dependencies:

--- a/rateslib/instruments.py
+++ b/rateslib/instruments.py
@@ -27,7 +27,6 @@ import abc
 import warnings
 
 import numpy as np
-from scipy.optimize import brentq
 from pandas.tseries.offsets import CustomBusinessDay
 from pandas import DataFrame, concat, date_range, Series
 
@@ -922,8 +921,11 @@ class FixedRateBond(Sensitivities, BaseMixin):
         """
 
         def root(y):
-            return self._price_from_ytm(y, settlement, dirty) - price
-        x = brentq(root, -99, 10000)
+            # we set this to work in float arithmetic for efficiency. Dual is added
+            # back below, see PRx
+            return self._price_from_ytm(y, settlement, dirty) - float(price)
+        # x = brentq(root, -99, 10000)  # remove dependence to scipy brentq
+        x, iters = _brents(root, -99, 10000)
 
         if isinstance(price, Dual):
             # use the inverse function theorem to express x as a Dual
@@ -1028,7 +1030,6 @@ class FixedRateBond(Sensitivities, BaseMixin):
             return forward_price
         else:
             return forward_price - self.accrued(forward_settlement)
-
 
     # Digital Methods
 
@@ -5465,3 +5466,61 @@ def forward_fx(
 # Licence: Creative Commons - Attribution-NonCommercial-NoDerivatives 4.0 International
 # Commercial use of this code, and/or copying and redistribution is prohibited.
 # Contact rateslib at gmail.com if this code is observed outside its intended sphere.
+
+
+def _brents(f, x0, x1, max_iter=50, tolerance=1e-12):
+    fx0 = f(x0)
+    fx1 = f(x1)
+
+    if float(fx0 * fx1) > 0:
+        raise ValueError(
+            "`brents` must initiate from function values with opposite signs.")
+
+    if abs(fx0) < abs(fx1):
+        x0, x1 = x1, x0
+        fx0, fx1 = fx1, fx0
+
+    x2, fx2 = x0, fx0
+
+    mflag = True
+    steps_taken = 0
+
+    while steps_taken < max_iter and abs(x1 - x0) > tolerance:
+        fx0 = f(x0)
+        fx1 = f(x1)
+        fx2 = f(x2)
+
+        if fx0 != fx2 and fx1 != fx2:
+            L0 = (x0 * fx1 * fx2) / ((fx0 - fx1) * (fx0 - fx2))
+            L1 = (x1 * fx0 * fx2) / ((fx1 - fx0) * (fx1 - fx2))
+            L2 = (x2 * fx1 * fx0) / ((fx2 - fx0) * (fx2 - fx1))
+            new = L0 + L1 + L2
+
+        else:
+            new = x1 - ((fx1 * (x1 - x0)) / (fx1 - fx0))
+
+        if ((float(new) < float((3 * x0 + x1) / 4) or float(new) > float(x1)) or
+                (mflag == True and (abs(new - x1)) >= (abs(x1 - x2) / 2)) or
+                (mflag == False and (abs(new - x1)) >= (abs(x2 - d) / 2)) or
+                (mflag == True and (abs(x1 - x2)) < tolerance) or
+                (mflag == False and (abs(x2 - d)) < tolerance)):
+            new = (x0 + x1) / 2
+            mflag = True
+
+        else:
+            mflag = False
+
+        fnew = f(new)
+        d, x2 = x2, x1
+
+        if float(fx0 * fnew) < 0:
+            x1 = new
+        else:
+            x0 = new
+
+        if abs(fx0) < abs(fx1):
+            x0, x1 = x1, x0
+
+        steps_taken += 1
+
+    return x1, steps_taken

--- a/rateslib/instruments.py
+++ b/rateslib/instruments.py
@@ -922,7 +922,7 @@ class FixedRateBond(Sensitivities, BaseMixin):
 
         def root(y):
             # we set this to work in float arithmetic for efficiency. Dual is added
-            # back below, see PRx
+            # back below, see PR GH3
             return self._price_from_ytm(y, settlement, dirty) - float(price)
         # x = brentq(root, -99, 10000)  # remove dependence to scipy brentq
         x, iters = _brents(root, -99, 10000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@
 jupyterlab==3.3.1
 numpy==1.23.5
 pandas==1.5.3
-scipy==1.9.3
 matplotlib==3.6.3
 
 # possible performance enhancements


### PR DESCRIPTION
Writes a version of Brent root finding algorithm in local code.
This is about 6 times slower than scipy `brentq` possibly more, but it eliminates a complete dependency.