### PR TITLE
ENH: take `collateral` from `disc_curve` and use it within `cashflows_table`

### DIFF
--- a/docs/source/i_whatsnew.rst
+++ b/docs/source/i_whatsnew.rst
@@ -4,7 +4,7 @@
 Release Notes
 **************
 
-Proper release notes started being recorded after version 0.3.x
+More detailed release notes started being recorded after version 0.3.x
 
 0.4.0 (not released)
 ********************
@@ -12,10 +12,15 @@ Proper release notes started being recorded after version 0.3.x
 Refactors and Enhancements
 --------------------------
 
+- Added an ``FXExchange`` class to provide booking FXSpot or FXForward trades of simple FX
+  exchanges.
 - Remove all *LegExchange* types and add ``initial_exchange`` and
   ``final_exchange`` as arguments to basic *Legs* to replace the functionality.
 - Added historic fixing data until end July for ESTR, SOFR,
   SWESTR, SONIA and NOWA, for testing and validation.
+- Caching calendars improves general performance by about 10%.
+- Collateral tags were added to *Curves* to permit the new method ``cashflows_table`` which
+  tabulates futures cashflows according to currency and collateral type.
 
 Bug Fixes
 ---------
@@ -29,3 +34,5 @@ Bug Fixes
   and 'zur', and validated historic fixings against the historic fixing data.
 - Now allow *CompositeCurve* to be constructed from *ProxyCurve* and *Curve*
   combinations.
+- The ``payment_lag_exchange`` parameter for ``FXSwap`` was removed in favour of using
+  ``payment_lag``.

--- a/rateslib/default.py
+++ b/rateslib/default.py
@@ -153,6 +153,7 @@ class Defaults:
         "index_value": "Index Val",
         "index_ratio": "Index Ratio",
         "index_base": "Index Base",
+        "collateral": "Collateral",
     }
     algorithm = "gauss_newton"
     curve_not_in_solver = "ignore"

--- a/rateslib/default.py
+++ b/rateslib/default.py
@@ -15,7 +15,8 @@ class Fixings:
     def _load_csv(path):
         abspath = os.path.dirname(os.path.abspath(__file__))
         target = os.path.join(abspath, path)
-        if version.parse(pandas.__version__) < version.parse("2.0"):
+        if version.parse(pandas.__version__) < version.parse("2.0"):  # pragma: no cover
+            # this is tested by the minimum version gitflow actions.
             # TODO remove when pandas min version is bumped to 2.0
             df = read_csv(target)
             df["reference_date"] = df["reference_date"].map(lambda x: datetime.strptime(x, "%d-%m-%Y"))

--- a/rateslib/instruments.py
+++ b/rateslib/instruments.py
@@ -7777,7 +7777,8 @@ class Fly(Sensitivities):
 #         return 2 * self.instrument2.rate(*args2) - self.instrument1.rate(*args1) - self.instrument3.rate(*args3)
 
 
-def _instrument_npv(instrument, *args, **kwargs):
+def _instrument_npv(instrument, *args, **kwargs):  # pragma: no cover
+    # this function is captured by TestPortfolio pooling but is not registered as a parallel process
     # used for parallel processing with Portfolio.npv
     return instrument.npv(*args, **kwargs)
 

--- a/rateslib/instruments.py
+++ b/rateslib/instruments.py
@@ -7246,12 +7246,6 @@ class FXSwap(BaseXCS):
     points : float, optional
         The pricing parameter for the FX Swap, which will determine the implicit
         fixed rate on leg2.
-    payment_lag_exchange : int
-        The number of business days by which to delay notional exchanges, aligned with
-        the accrual schedule. Defaults to 0 for *FXSwaps*.
-    leg2_payment_lag_exchange : int
-        The number of business days by which to delay notional exchanges, aligned with
-        the accrual schedule. Defaults to 0 for *FXSwaps*.
     kwargs : dict
         Required keyword arguments to :class:`BaseDerivative`.
 
@@ -7328,15 +7322,15 @@ class FXSwap(BaseXCS):
         *args,
         fx_fixing: Optional[Union[float, FXRates, FXForwards]] = None,
         points: Optional[float] = None,
-        payment_lag_exchange: Optional[int] = None,
-        leg2_payment_lag_exchange: Optional[int] = "inherit",
+        # payment_lag_exchange: Optional[int] = None,
+        # leg2_payment_lag_exchange: Optional[int] = "inherit",
         **kwargs,
     ):
         if fx_fixing is None and points is not None:
             raise ValueError("Cannot set `points` on FXSwap without giving an `fx_fixing`.")
         super().__init__(*args, **kwargs)
-        if leg2_payment_lag_exchange == "inherit":
-            leg2_payment_lag_exchange = payment_lag_exchange
+        # if leg2_payment_lag_exchange == "inherit":
+        #     leg2_payment_lag_exchange = payment_lag_exchange
         self._fixed_rate = 0.0
         self.leg1 = FixedLeg(
             fixed_rate=0.0,
@@ -7345,8 +7339,8 @@ class FXSwap(BaseXCS):
             frequency="Z",
             modifier=self.modifier,
             calendar=self.calendar,
-            payment_lag=payment_lag_exchange,
-            payment_lag_exchange=payment_lag_exchange,
+            payment_lag=self.payment_lag,
+            payment_lag_exchange=self.payment_lag,
             notional=self.notional,
             currency=self.currency,
             convention=self.convention,
@@ -7360,8 +7354,8 @@ class FXSwap(BaseXCS):
             frequency="Z",
             modifier=self.leg2_modifier,
             calendar=self.leg2_calendar,
-            payment_lag=leg2_payment_lag_exchange,
-            payment_lag_exchange=leg2_payment_lag_exchange,
+            payment_lag=self.leg2_payment_lag,
+            payment_lag_exchange=self.leg2_payment_lag,
             notional=self.leg2_notional,
             currency=self.leg2_currency,
             convention=self.leg2_convention,
@@ -7405,7 +7399,7 @@ class FXSwap(BaseXCS):
 
     def rate(
         self,
-        curves: Union[Curve, str, list],
+        curves: Optional[Union[Curve, str, list]] = None,
         solver: Optional[Solver] = None,
         fx: Optional[FXForwards] = None,
         fixed_rate: bool = False,

--- a/rateslib/periods.py
+++ b/rateslib/periods.py
@@ -60,7 +60,9 @@ def _get_fx_and_base(
                 raise ValueError(
                     f"`base` ({base}) cannot be requested without supplying `fx` as a "
                     "valid FXRates or FXForwards object to convert to "
-                    f"currency ({currency})."
+                    f"currency ({currency}).\n"
+                    "If you are using a `Solver` with multi-currency instruments have you "
+                    "forgotten to attach the FXForwards in the solver's `fx` argument?"
                 )
             fx = 1.0
         else:

--- a/rateslib/periods.py
+++ b/rateslib/periods.py
@@ -292,6 +292,7 @@ class BasePeriod(metaclass=ABCMeta):
             defaults.headers["dcf"]: self.dcf,
             defaults.headers["notional"]: float(self.notional),
             defaults.headers["df"]: None if disc_curve is None else float(disc_curve[self.payment]),
+            defaults.headers["collateral"]: None if disc_curve is None else disc_curve.collateral,
         }
 
     @abstractmethod
@@ -1664,6 +1665,7 @@ class Cashflow:
             defaults.headers["npv"]: npv,
             defaults.headers["fx"]: float(fx),
             defaults.headers["npv_fx"]: npv_fx,
+            defaults.headers["collateral"]: None if disc_curve is None else disc_curve.collateral,
         }
 
     @property

--- a/tests/test_instruments.py
+++ b/tests/test_instruments.py
@@ -1804,7 +1804,7 @@ class TestFXSwap:
             "M",
             currency="usd",
             leg2_currency="nok",
-            payment_lag_exchange=0,
+            payment_lag=0,
             notional=1e6,
         )
         expected = fxf.swap("usdnok", [dt(2022, 2, 1), dt(2022, 10, 1)])
@@ -1822,7 +1822,7 @@ class TestFXSwap:
             "M",
             currency="usd",
             leg2_currency="nok",
-            payment_lag_exchange=0,
+            payment_lag=0,
             notional=1e6,
         )
 
@@ -1858,7 +1858,7 @@ class TestFXSwap:
             points=1754.56233604,
             currency="usd",
             leg2_currency="nok",
-            payment_lag_exchange=0,
+            payment_lag=0,
             notional=1e6,
         )
         npv = fxs.npv([None, curve, None, curve2], None, fxf)

--- a/tests/test_periods.py
+++ b/tests/test_periods.py
@@ -186,6 +186,7 @@ class TestFloatPeriod:
             Defaults.headers["cashflow"]: cashflow,
             Defaults.headers["fx"]: fx,
             Defaults.headers["npv_fx"]: -10096746.871171726 * fx if crv else None,
+            Defaults.headers["collateral"]: None,
         }
         if fx == 2.0:
             with pytest.warns(UserWarning):
@@ -1126,6 +1127,7 @@ class TestFixedPeriod:
             Defaults.headers["cashflow"]: cashflow,
             Defaults.headers["fx"]: fx,
             Defaults.headers["npv_fx"]: -9897791.268897855 * fx if crv else None,
+            Defaults.headers["collateral"]: None,
         }
         if fx == 2.0:
             with pytest.warns(UserWarning):
@@ -1203,6 +1205,7 @@ class TestCashflow:
             Defaults.headers["cashflow"]: -1e9,
             Defaults.headers["fx"]: fx,
             Defaults.headers["npv_fx"]: -989779126.8897856 * fx if crv else None,
+            Defaults.headers["collateral"]: None,
         }
         if fx == 2.0:
             with pytest.warns(UserWarning):
@@ -1429,6 +1432,7 @@ class TestIndexFixedPeriod:
             "NPV": -19795582.53779571 if curve_ else None,
             "FX Rate": 1.0,
             "NPV Ccy": -19795582.53779571 if curve_ else None,
+            Defaults.headers["collateral"]: None,
         }
         assert result == expected
 


### PR DESCRIPTION
This allows the collateral tag asserts from a discount curve to be collated by a cashflows table.