### PR TITLE
Update g_curves.rst

### DIFF
--- a/docs/source/c_curves.rst
+++ b/docs/source/c_curves.rst
@@ -94,7 +94,7 @@ required.
 .. ipython:: python
    :okwarning:
 
-   from datetime import datetime as dt
+   from rateslib import dt
    curve = Curve(
        nodes={
            dt(2022,1,1): 1.0,  # <- initial DF should always be 1.0
@@ -196,7 +196,7 @@ and :class:`~rateslib.curves.LineCurve`.
 
    from rateslib.curves import *
    import matplotlib.pyplot as plt
-   from datetime import datetime as dt
+   from rateslib import dt
    import numpy as np
    curve = Curve(
        nodes={
@@ -257,7 +257,7 @@ The available basic local interpolation options are:
 
    from rateslib.curves import *
    import matplotlib.pyplot as plt
-   from datetime import datetime as dt
+   from rateslib import dt
    import numpy as np
    curve = Curve(
        nodes={
@@ -309,7 +309,7 @@ those copied from the curve.
 
    from rateslib.curves import *
    import matplotlib.pyplot as plt
-   from datetime import datetime as dt
+   from rateslib import dt
    import numpy as np
 
    curve = Curve(
@@ -396,7 +396,7 @@ the curve. This is common practice for interest rate curves usually with a
 
    from rateslib.curves import *
    import matplotlib.pyplot as plt
-   from datetime import datetime as dt
+   from rateslib import dt
    import numpy as np
    curve = Curve(
        nodes={

--- a/docs/source/g_curves.rst
+++ b/docs/source/g_curves.rst
@@ -62,7 +62,7 @@ generalised process of:
    from rateslib.curves import Curve
    from rateslib.solver import Solver
    from rateslib.instruments import IRS
-   from datetime import datetime as dt
+   from rateslib import dt
 
    sofr = Curve(
        nodes={
@@ -98,7 +98,7 @@ generalised process of:
    from rateslib.curves import Curve
    from rateslib.solver import Solver
    from rateslib.instruments import IRS
-   from datetime import datetime as dt
+   from rateslib import dt
 
    sofr = Curve(
        nodes={

--- a/docs/source/g_curves.rst
+++ b/docs/source/g_curves.rst
@@ -62,6 +62,7 @@ generalised process of:
    from rateslib.curves import Curve
    from rateslib.solver import Solver
    from rateslib.instruments import IRS
+   from datetime import datetime as dt
 
    sofr = Curve(
        nodes={


### PR DESCRIPTION
Hi,

Not sure if you will accept PRs, if not just close this. I have simply added 
```
from datetime import datetime as dt
```
to the example presented in Constructing Curves as without it the example would not run. In the source code I can see that 

```
from rateslib import dt
```

is used. However, as 
```
from datetime import datetime as dt
```
is used in the introduction of the Curves section in the documentations I have assumed this is preferable. 