### PR TITLE
BUG: `solver.delta` and `solver.gamma` operate directly on `npv` when `fx` not given

### DIFF
--- a/docs/source/i_whatsnew.rst
+++ b/docs/source/i_whatsnew.rst
@@ -57,6 +57,8 @@ email contact through **rateslib@gmail.com**.
    * - Instruments
      - Added argument ``metric`` to :class:`~rateslib.instruments.Value` so that specific *Curve* values derived
        as calculated figures (e.g. continuously compounded zero rate, or index value) can be calibrated by *Solvers*.
+   * - Bug
+     - `Solver.delta` and `Solver.gamma` now work directly with given ``npv`` when ``fx`` is not provided.
 
 
 1.0.0 (1st Feb 2024)

--- a/rateslib/solver.py
+++ b/rateslib/solver.py
@@ -1394,7 +1394,7 @@ class Solver(Gradients):
     # Commercial use of this code, and/or copying and redistribution is prohibited.
     # Contact rateslib at gmail.com if this code is observed outside its intended sphere.
 
-    def delta(self, npv, base: Union[str, NoInput] = NoInput(0), fx=None):
+    def delta(self, npv, base: Union[str, NoInput] = NoInput(0), fx=NoInput(0)):
         """
         Calculate the delta risk sensitivity of an instrument's NPV to the
         calibrating instruments of the :class:`~rateslib.solver.Solver`, and to
@@ -1527,7 +1527,7 @@ class Solver(Gradients):
             base = base.lower()
         return base, fx
 
-    def gamma(self, npv, base=None, fx=None):
+    def gamma(self, npv, base=NoInput(0), fx=NoInput(0)):
         """
         Calculate the cross-gamma risk sensitivity of an instrument's NPV to the
         calibrating instruments of the :class:`~rateslib.solver.Solver`.
@@ -1752,7 +1752,7 @@ class Solver(Gradients):
 
         return df.astype("float64")
 
-    def _pnl_explain(self, npv, ds, dfx=None, base=None, fx=None, order=1):
+    def _pnl_explain(self, npv, ds, dfx=None, base=NoInput(0), fx=NoInput(0), order=1):
         """
         Calculate PnL from market movements over delta and, optionally, gamma.
 

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -588,6 +588,23 @@ def test_delta_gamma_calculation():
     assert -229 < float(eur_swap.gamma(NoInput(0), estr_solver).sum().sum()) < -228
 
 
+def test_solver_delta_fx_noinput():
+    estr_curve = Curve(
+        {dt(2022, 1, 1): 1.0, dt(2032, 1, 1): 1.0, dt(2042, 1, 1): 1.0}, id="estr_curve"
+    )
+    estr_instruments = [
+        (IRS(dt(2022, 1, 1), "10Y", "A"), (estr_curve,), {}),
+        (IRS(dt(2022, 1, 1), "20Y", "A"), (estr_curve,), {}),
+    ]
+    estr_solver = Solver(
+        [estr_curve], estr_instruments, [2.0, 1.5], id="estr", instrument_labels=["10Y", "20Y"]
+    )
+    eur_swap = IRS(dt(2032, 1, 1), "10Y", "A", notional=100e6, fixed_rate=2)
+    npv = eur_swap.npv(curves=estr_curve, solver=estr_solver, local=True)
+    result = estr_solver.delta(npv)
+    assert type(result) is DataFrame
+
+
 def test_solver_pre_solver_dependency_generates_same_gamma():
     estr_curve = Curve({dt(2022, 1, 1): 1.0, dt(2032, 1, 1): 1.0, dt(2042, 1, 1): 1.0})
     estr_instruments = [


### PR DESCRIPTION
Required `NoInput` conversion.