### PR TITLE
PERF: Add short circuit to improve `Splines`

### DIFF
--- a/docs/source/i_whatsnew.rst
+++ b/docs/source/i_whatsnew.rst
@@ -69,6 +69,9 @@ email contact through **rateslib@gmail.com**.
    * - Performance
      - Curve iterations in the :class:`~rateslib.solver.Solver` were amended in the way they handle
        :class:`~rateslib.dual.Dual` variables in order to reduce upcasting and increase the speed of basic operations.
+   * - Performance
+     - :class:`_rateslib.splines.bsplev_single` introduced a short circuit based on the positivity and support
+       property to greatly improve time needed to solve curves with splines.
 
 
 1.0.0 (1st Feb 2024)

--- a/docs/source/i_whatsnew.rst
+++ b/docs/source/i_whatsnew.rst
@@ -70,7 +70,7 @@ email contact through **rateslib@gmail.com**.
      - Curve iterations in the :class:`~rateslib.solver.Solver` were amended in the way they handle
        :class:`~rateslib.dual.Dual` variables in order to reduce upcasting and increase the speed of basic operations.
    * - Performance
-     - :class:`_rateslib.splines.bsplev_single` introduced a short circuit based on the positivity and support
+     - :class:`~rateslib.splines.bsplev_single` introduced a short circuit based on the positivity and support
        property to greatly improve time needed to solve curves with splines.
 
 

--- a/rateslib/splines.py
+++ b/rateslib/splines.py
@@ -56,18 +56,22 @@ def bsplev_single(x, i, k, t, org_k=None):
     For continuity on the right boundary the rightmost basic b-spline is also set equal
     to 1 there: :math:`B_{n,1,\\mathbf{t}}(t_{n+k})=1`.
     """
-    # Right side endpoint support
+    # Short circuit (positivity and support property)
+    if x < t[i] or x > t[i+k]:
+        return 0.
+
     org_k = org_k or k  # original_k adds support for derivative recursion
+    # Right side endpoint support
     if x == t[-1] and i >= (len(t) - org_k - 1):
-        return 1
+        return 1.
 
     # Recursion
     if k == 1:
         if t[i] <= x < t[i + 1]:
-            return 1
-        return 0
+            return 1.
+        return 0.
     else:
-        left, right = 0, 0
+        left, right = 0., 0.
         if t[i] != t[i + k - 1]:
             left = (x - t[i]) / (t[i + k - 1] - t[i]) * bsplev_single(x, i, k - 1, t)
         if t[i + 1] != t[i + k]:


### PR DESCRIPTION
This was benchmarked.

```python
from rateslib import *

dates = [
    dt(2000, 1, 1),
    dt(2001, 1, 1),
    dt(2002, 1, 1),
    dt(2003, 1, 1),
    dt(2004, 1, 1),
    dt(2005, 1, 1),
    dt(2006, 1, 1),
    dt(2007, 1, 1),
    dt(2008, 1, 1),
    dt(2009, 1, 1),
    dt(2010, 1, 1),
    dt(2012, 1, 1),
    dt(2015, 1, 1),
    dt(2020, 1, 3),
]

curve = Curve(
    nodes={_: 1.0 for _ in dates},
    t=[dt(2000, 1, 1), dt(2000, 1, 1), dt(2000, 1, 1)] + dates + [dt(2020, 1, 3), dt(2020, 1, 3), dt(2020, 1, 3)],
)

solver = Solver(
    curves=[curve],
    instruments=[
        IRS(effective=dt(2000, 1, 1), termination=_, spec="gbp_irs", curves=curve) for _ in dates[1:]
    ],
    s=[1.0 + _ / 100 for _ in range(13)]
)
```

Before this PR: SUCCESS in 6.33s, `bsplev_single` evaluations: 701085

After this PR: SUCCESS in 1.83s, `bsplev_single` evaluations: 176445
