### PR TITLE
BUG: FXSwap with unpriced `split_notional` transition from Dual to Dual2

### DIFF
--- a/rateslib/__init__.py
+++ b/rateslib/__init__.py
@@ -74,7 +74,7 @@ from rateslib.curves import (
     ProxyCurve,
 )
 
-from rateslib.fx_volatility import FXDeltaVolSmile
+from rateslib.fx_volatility import FXDeltaVolSmile, FXDeltaVolSurface
 
 from rateslib.fx import (
     FXRates,
@@ -183,6 +183,7 @@ __all__ = [
     "index_left",
     # fx_volatility.py
     "FXDeltaVolSmile",
+    "FXDeltaVolSurface",
     # solver.py
     "Solver",
     # fx.py

--- a/rateslib/curves.py
+++ b/rateslib/curves.py
@@ -1217,7 +1217,12 @@ class Curve(_Serialize):
         self.csolve()
 
     def _get_node_vector(self):
+        """Get a 1d array of variables associated with nodes of this object updated by Solver"""
         return np.array(list(self.nodes.values())[self._ini_solve:])
+
+    def _get_node_vars(self):
+        """Get the variable names of elements updated by a Solver"""
+        return tuple((f"{self.id}{i}" for i in range(self._ini_solve, self.n)))
 
 
 class LineCurve(Curve):

--- a/rateslib/instruments.py
+++ b/rateslib/instruments.py
@@ -69,7 +69,7 @@ from rateslib.dual import (
     gradient,
 )
 from rateslib.fx import FXForwards, FXRates, forward_fx
-from rateslib.fx_volatility import FXDeltaVolSmile
+from rateslib.fx_volatility import FXDeltaVolSmile, FXVolObj
 
 
 # Licence: Creative Commons - Attribution-NonCommercial-NoDerivatives 4.0 International
@@ -8306,7 +8306,7 @@ class FXOption(Sensitivities, metaclass=ABCMeta):
             # at this stage. Similar to setting a fixed rate as a float on an unpriced IRS for mid-market.
             self.periods[0].strike = float(self._pricing["k"])
 
-        if isinstance(vol, FXDeltaVolSmile):
+        if isinstance(vol, FXVolObj):
             if self._pricing["delta_index"] is None:
                 self._pricing["delta_index"], self._pricing["vol"], _ = vol.get_from_strike(
                     k=self._pricing["k"],
@@ -8317,7 +8317,7 @@ class FXOption(Sensitivities, metaclass=ABCMeta):
                     expiry=self.kwargs["expiry"]
                 )
             else:
-                self._pricing["vol"] = vol[self._pricing["delta_index"]]
+                self._pricing["vol"] = vol._get_index(self._pricing["delta_index"], self.kwargs["expiry"])
 
     def _set_premium(
         self,
@@ -8660,8 +8660,10 @@ class FXOptionStrat:
 
         See :meth:`~rateslib.instruments.FXOption.rate`.
         """
-        if not isinstance(vol, list):
-            vol = [vol] * len(self.periods)
+        curves, fx, base = _get_curves_fx_and_base_maybe_from_solver(
+            self.curves, solver, curves, fx, base, self.kwargs["pair"][3:]
+        )
+        vol = self._vol_as_list(vol, solver)
 
         metric = metric if metric is not NoInput.blank else self.kwargs["metric"]
         map_ = {

--- a/rateslib/instruments.py
+++ b/rateslib/instruments.py
@@ -7491,10 +7491,11 @@ class XCS(BaseDerivative):
             # and impact solvers. A better solution may be to trace the
             # the variables and never use an old value. Always rely on initiated values,
             # which are NOT Dual variables.
-            self.leg2_notional = self.leg1.notional * -float(fx_arg)
+            self.leg2_notional = self.kwargs["notional"] * fx_arg
             self.leg2.notional = self.leg2_notional
-            self.leg2_amortization = self.leg1.amortization * -float(fx_arg)
-            self.leg2.amortization = self.leg2_amortization
+            if self.kwargs["amortization"] is not NoInput.blank:
+                self.leg2_amortization = self.kwargs["amortization"] * -fx_arg
+                self.leg2.amortization = self.leg2_amortization
 
     @property
     def _is_unpriced(self):
@@ -7927,7 +7928,7 @@ class FXSwap(XCS):
                 # TODO this is a very subtle change for Solvers:
                 # Split notional AD information is lost here - the instrumenst notionals
                 # are assumed to be fixed after this determination.
-                self._split_notional = self.kwargs["notional"] * float(curve[dt1] / curve[dt2])
+                self._split_notional = self.kwargs["notional"] * curve[dt1] / curve[dt2]
                 self._set_leg1_fixed_rate()
 
     def _set_leg1_fixed_rate(self):

--- a/rateslib/solver.py
+++ b/rateslib/solver.py
@@ -993,6 +993,7 @@ class Solver(Gradients):
             self.weights = np.asarray(weights)
         self.W = np.diag(self.weights)
 
+        # `surfaces` are treated identically to `curves`. Introduced in PR
         self.curves = {
             curve.id: curve
             for curve in list(curves) + list(surfaces)
@@ -1002,8 +1003,7 @@ class Solver(Gradients):
         self.variables = ()
         for curve in self.curves.values():
             curve._set_ad_order(1)  # solver uses gradients in optimisation
-            curve_vars = tuple((f"{curve.id}{i}" for i in range(curve._ini_solve, curve.n)))
-            self.variables += curve_vars
+            self.variables += curve._get_node_vars()
         self.n = len(self.variables)
 
         # aggregate and organise variables and labels including pre_solvers

--- a/tests/test_instruments.py
+++ b/tests/test_instruments.py
@@ -2323,6 +2323,25 @@ class TestFXSwap:
     #     npv_usd = fxs.npv([NoInput(0), curve, NoInput(0), fxf.curve("nok", "usd")], NoInput(0), fxf)
     #     assert abs(npv_nok-npv_usd) < 1e-7  # npvs are equivalent becasue xcs basis =0
 
+    def test_transition_from_dual_to_dual2(self, curve, curve2):
+        # Test added for BUG, see PR: XXX
+        fxf = FXForwards(
+            FXRates({"usdnok": 10}, settlement=dt(2022, 1, 3)),
+            {"usdusd": curve, "nokusd": curve2, "noknok": curve2},
+        )
+        fxf._set_ad_order(1)
+        fxs = FXSwap(
+            dt(2022, 2, 1),
+            "8M",
+            currency="usd",
+            leg2_currency="nok",
+            payment_lag=0,
+            notional=1e6,
+        )
+        fxs.npv(curves=[None, fxf.curve("usd", "usd"), None, fxf.curve("nok", "usd")], fx=fxf)
+        fxf._set_ad_order(2)
+        fxs.npv(curves=[None, fxf.curve("usd", "usd"), None, fxf.curve("nok", "usd")], fx=fxf)
+
 
 class TestSTIRFuture:
     def test_stir_rate(self, curve, curve2):

--- a/tests/test_instruments.py
+++ b/tests/test_instruments.py
@@ -2338,7 +2338,10 @@ class TestFXSwap:
             payment_lag=0,
             notional=1e6,
         )
-        fxs.npv(curves=[None, fxf.curve("usd", "usd"), None, fxf.curve("nok", "usd")], fx=fxf)
+        fxs.npv(
+            curves=[None, fxf.curve("usd", "usd"), None, fxf.curve("nok", "usd")],
+            fx=fxf
+        )
         fxf._set_ad_order(2)
         fxs.npv(curves=[None, fxf.curve("usd", "usd"), None, fxf.curve("nok", "usd")], fx=fxf)
 


### PR DESCRIPTION
Notional and Amortization on an FXswap may be unpriced, i.e. they are dynamically determined. If a pricing systems (solver or curves or FXforwards) transitions to Dual2 these notionals may have stale Dual values which affect the current calculation and Dual and Dual2 Types cannot cross mix.