### PR TITLE
BUG: FXForwards immediate: many currency systems may avoid reorder

### DIFF
--- a/python/rateslib/fx.py
+++ b/python/rateslib/fx.py
@@ -1075,7 +1075,7 @@ class FXForwards:
                 pair = f"{cash_ccy}{coll_ccy}"
                 fx_rates_immediate.update({pair: self.fx_rates.fx_array[row, col] * v_i / w_i})
 
-        fx_rates_immediate = FXRates(fx_rates_immediate, self.immediate)
+        fx_rates_immediate = FXRates(fx_rates_immediate, self.immediate, self.base)
         return fx_rates_immediate.restate(self.fx_rates.pairs, keep_ad=True)
 
     def rate(


### PR DESCRIPTION
This should be investigated more thoroughky by creating hypothesis of various types of FXRates currencies list and FXForwards curve frameworks which potentially can change the ordeing or currencies and then cause errors in the matrix solving becuase the indices of elements do not match the ordering of currencies.

Possibly the `restate` method which is called after this could ensure that the currencies list retains a specific ordering.