### PR TITLE
BUG: correct set order ad for 2nd order FXRates

### DIFF
--- a/docs/source/i_whatsnew.rst
+++ b/docs/source/i_whatsnew.rst
@@ -73,6 +73,10 @@ email contact through **rateslib@gmail.com**.
      - Solving acyclic *FXForwards* systems is now stable for all orderings of currencies, and does not depend
        on a well chosen ``base`` currency.
    * - Bug
+     - Converting an `fx_array` associated with the :class:`~rateslib.fx.FXRates` into second order for AD
+       calculations now captures second order FX derivatives correctly by rebuilding the array, instead of a
+       direct conversion setting second order derivatives to zero.
+   * - Bug
      - Entering the *"single_vol"* ``metric`` into the :meth:`~rateslib.instruments.FXBrokerFly.rate` method
        of a :class:`~rateslib.instruments.FXBrokerFly` no longer raises.
    * - Errors

--- a/python/rateslib/dual/__init__.py
+++ b/python/rateslib/dual/__init__.py
@@ -13,7 +13,7 @@ else:
     from rateslib.dual.dualrs import Dual, Dual2
 
 from rateslib.dual.dual import FLOATS, INTS, _dsolve
-from rateslib.dual.dualrs import _dsolve1, _dsolve2, _fdsolve1, _fdsolve2
+from rateslib.dual.dualrs import _dsolve1, _dsolve2, _fdsolve1, _fdsolve2, ADOrder
 
 DualTypes = Union[float, Dual, Dual2]
 # Licence: Creative Commons - Attribution-NonCommercial-NoDerivatives 4.0 International
@@ -262,3 +262,14 @@ def dual_solve(A, b, allow_lsq=False, types=(Dual, Dual)):
         out = _fdsolve2(A_, b, allow_lsq)
 
     return np.array(out)[:, None]
+
+
+def _get_adorder(order: int):
+    if order == 1:
+        return ADOrder.One
+    elif order == 0:
+        return ADOrder.Zero
+    elif order == 2:
+        return ADOrder.Two
+    else:
+        raise ValueError("Order for AD can only be in {0,1,2}")

--- a/python/rateslib/dual/dualrs.py
+++ b/python/rateslib/dual/dualrs.py
@@ -1,4 +1,4 @@
-from rateslib.rs import Dual, Dual2, _dsolve1, _dsolve2, _fdsolve1, _fdsolve2
+from rateslib.rs import Dual, Dual2, _dsolve1, _dsolve2, _fdsolve1, _fdsolve2, ADOrder
 
 Dual.__doc__ = "Dual number data type to perform first derivative automatic differentiation."
 Dual2.__doc__ = "Dual number data type to perform second derivative automatic differentiation."

--- a/python/rateslib/fx/fx_rates.py
+++ b/python/rateslib/fx/fx_rates.py
@@ -7,7 +7,7 @@ from pandas import DataFrame, Series
 
 from rateslib import defaults
 from rateslib.default import NoInput, _make_py_json, _drb
-from rateslib.dual import Dual, DualTypes, gradient
+from rateslib.dual import Dual, DualTypes, gradient, _get_adorder
 from rateslib.rs import FXRates as FXRatesObj, FXRate, Ccy
 
 """
@@ -506,7 +506,8 @@ class FXRates:
         """
         Change the node values to float, Dual or Dual2 based on input parameter.
         """
-        self.obj.set_ad_order(order)
+
+        self.obj.set_ad_order(_get_adorder(order))
         self.__init_post_obj__()
 
     def to_json(self):

--- a/src/dual/dual.rs
+++ b/src/dual/dual.rs
@@ -39,26 +39,14 @@ pub struct Dual2 {
     pub(crate) dual2: Array2<f64>,
 }
 
-impl From<Dual2> for Dual {
-    fn from(value: Dual2) -> Self {
-        Dual {
-            real: value.real,
-            vars: value.vars.clone(),
-            dual: value.dual,
-        }
-    }
-}
-
-impl From<Dual> for Dual2 {
-    fn from(value: Dual) -> Self {
-        let n = value.dual.len_of(Axis(0));
-        Dual2 {
-            real: value.real,
-            vars: value.vars.clone(),
-            dual: value.dual,
-            dual2: Array2::zeros((n, n)),
-        }
-    }
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum ADOrder{
+    /// Floating point arithmetic only.
+    Zero,
+    /// Derivatives available to first order.
+    One,
+    /// Derivatives available to second order.
+    Two,
 }
 
 /// The state of the `vars` measured between two dual number type structs; a LHS relative to a RHS.

--- a/src/dual/dual.rs
+++ b/src/dual/dual.rs
@@ -15,7 +15,7 @@ pub use crate::dual::dual_ops::math_funcs::MathFuncs;
 use indexmap::set::IndexSet;
 use ndarray::{Array, Array1, Array2, Axis};
 use pyo3::exceptions::PyValueError;
-use pyo3::{pyclass, PyErr};
+use pyo3::{FromPyObject, pyclass, PyErr};
 use serde::{Deserialize, Serialize};
 use std::cmp::PartialEq;
 use std::sync::Arc;
@@ -37,6 +37,14 @@ pub struct Dual2 {
     pub(crate) vars: Arc<IndexSet<String>>,
     pub(crate) dual: Array1<f64>,
     pub(crate) dual2: Array2<f64>,
+}
+
+
+#[derive(Debug, Clone, PartialEq, PartialOrd, FromPyObject, Serialize, Deserialize)]
+pub enum DualsOrF64 {
+    Dual(Dual),
+    Dual2(Dual2),
+    F64(f64),
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/src/dual/dual.rs
+++ b/src/dual/dual.rs
@@ -47,6 +47,7 @@ pub enum DualsOrF64 {
     F64(f64),
 }
 
+#[pyclass(module = "rateslib.rs")]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum ADOrder {
     /// Floating point arithmetic only.

--- a/src/dual/dual_ops/from.rs
+++ b/src/dual/dual_ops/from.rs
@@ -1,4 +1,4 @@
-use crate::dual::dual::{Dual, Dual2};
+use crate::dual::dual::{Dual, Dual2, DualsOrF64};
 use ndarray::{Array2, Axis};
 
 impl From<Dual> for f64 {
@@ -9,6 +9,18 @@ impl From<Dual> for f64 {
 
 impl From<Dual2> for f64 {
     fn from(value: Dual2) -> Self {
+        value.real
+    }
+}
+
+impl From<&Dual> for f64 {
+    fn from(value: &Dual) -> Self {
+        value.real
+    }
+}
+
+impl From<&Dual2> for f64 {
+    fn from(value: &Dual2) -> Self {
         value.real
     }
 }
@@ -35,6 +47,16 @@ impl From<Dual2> for Dual {
     }
 }
 
+impl From<&Dual2> for Dual {
+    fn from(value: &Dual2) -> Self {
+        Dual {
+            real: value.real,
+            vars: value.vars.clone(),
+            dual: value.dual.clone(),
+        }
+    }
+}
+
 impl From<f64> for Dual2 {
     fn from(value: f64) -> Self {
         Self::new(value, vec![])
@@ -49,6 +71,78 @@ impl From<Dual> for Dual2 {
             vars: value.vars.clone(),
             dual: value.dual,
             dual2: Array2::zeros((n, n)),
+        }
+    }
+}
+
+impl From<&Dual> for Dual2 {
+    fn from(value: &Dual) -> Self {
+        let n = value.dual.len_of(Axis(0));
+        Dual2 {
+            real: value.real,
+            vars: value.vars.clone(),
+            dual: value.dual.clone(),
+            dual2: Array2::zeros((n, n)),
+        }
+    }
+}
+
+impl From<DualsOrF64> for f64 {
+    fn from(value: DualsOrF64) -> Self {
+        match value {
+            DualsOrF64::F64(f) => f,
+            DualsOrF64::Dual(d) => d.real,
+            DualsOrF64::Dual2(d) => d.real
+        }
+    }
+}
+
+impl From<DualsOrF64> for Dual {
+    fn from(value: DualsOrF64) -> Self {
+        match value {
+            DualsOrF64::F64(f) => Dual::new(f, vec![]),
+            DualsOrF64::Dual(d) => d,
+            DualsOrF64::Dual2(d) => Dual::from(d),
+        }
+    }
+}
+
+impl From<DualsOrF64> for Dual2 {
+    fn from(value: DualsOrF64) -> Self {
+        match value {
+            DualsOrF64::F64(f) => Dual2::new(f, vec![]),
+            DualsOrF64::Dual(d) => Dual2::from(d),
+            DualsOrF64::Dual2(d) => d,
+        }
+    }
+}
+
+impl From<&DualsOrF64> for f64 {
+    fn from(value: &DualsOrF64) -> Self {
+        match value {
+            DualsOrF64::F64(f) => *f,
+            DualsOrF64::Dual(d) => d.real,
+            DualsOrF64::Dual2(d) => d.real
+        }
+    }
+}
+
+impl From<&DualsOrF64> for Dual {
+    fn from(value: &DualsOrF64) -> Self {
+        match value {
+            DualsOrF64::F64(f) => Dual::new(*f, vec![]),
+            DualsOrF64::Dual(d) => d.clone(),
+            DualsOrF64::Dual2(d) => Dual::from(d),
+        }
+    }
+}
+
+impl From<&DualsOrF64> for Dual2 {
+    fn from(value: &DualsOrF64) -> Self {
+        match value {
+            DualsOrF64::F64(f) => Dual2::new(*f, vec![]),
+            DualsOrF64::Dual(d) => Dual2::from(d),
+            DualsOrF64::Dual2(d) => d.clone(),
         }
     }
 }

--- a/src/dual/dual_ops/from.rs
+++ b/src/dual/dual_ops/from.rs
@@ -1,0 +1,47 @@
+use crate::dual::dual::{Dual, Dual2};
+
+impl From<Dual> for f64 {
+    fn from(value: Dual) -> Self {
+        value.real
+    }
+}
+
+impl From<Dual2> for f64 {
+    fn from(value: Dual2) -> Self {
+        value.real
+    }
+}
+
+impl From<f64> for Dual {
+    fn from(value: f64) -> Self {
+        Self.new(value, vec![])
+    }
+}
+
+impl From<Dual2> for Dual {
+    fn from(value: Dual2) -> Self {
+        Dual {
+            real: value.real,
+            vars: value.vars.clone(),
+            dual: value.dual,
+        }
+    }
+}
+
+impl From<f64> for Dual2 {
+    fn from(value: f64) -> Self {
+        Self.new(value, vec![])
+    }
+}
+
+impl From<Dual> for Dual2 {
+    fn from(value: Dual) -> Self {
+        let n = value.dual.len_of(Axis(0));
+        Dual2 {
+            real: value.real,
+            vars: value.vars.clone(),
+            dual: value.dual,
+            dual2: Array2::zeros((n, n)),
+        }
+    }
+}

--- a/src/dual/dual_py.rs
+++ b/src/dual/dual_py.rs
@@ -11,7 +11,6 @@ use std::sync::Arc;
 use crate::json::json_py::DeserializedObj;
 use crate::json::JSON;
 use numpy::{Element, PyArray1, PyArray2, PyArrayDescr, ToPyArray};
-use serde::{Deserialize, Serialize};
 
 unsafe impl Element for Dual {
     const IS_COPY: bool = false;

--- a/src/dual/dual_py.rs
+++ b/src/dual/dual_py.rs
@@ -1,6 +1,6 @@
 //! Wrapper module to export Rust dual data types to Python using pyo3 bindings.
 
-use crate::dual::dual::{Dual, Dual2, Gradient1, Gradient2, Vars};
+use crate::dual::dual::{Dual, Dual2, Gradient1, Gradient2, Vars, DualsOrF64};
 use crate::dual::dual_ops::math_funcs::MathFuncs;
 use num_traits::{Pow, Signed};
 use pyo3::exceptions::{PyTypeError, PyValueError};
@@ -24,13 +24,6 @@ unsafe impl Element for Dual2 {
     fn get_dtype_bound(py: Python<'_>) -> Bound<'_, PyArrayDescr> {
         PyArrayDescr::object_bound(py)
     }
-}
-
-#[derive(Debug, Clone, PartialEq, PartialOrd, FromPyObject, Serialize, Deserialize)]
-pub enum DualsOrF64 {
-    Dual(Dual),
-    Dual2(Dual2),
-    F64(f64),
 }
 
 impl IntoPy<PyObject> for DualsOrF64 {

--- a/src/fx/rates/ccy.rs
+++ b/src/fx/rates/ccy.rs
@@ -1,0 +1,51 @@
+use internment::Intern;
+use pyo3::exceptions::PyValueError;
+use pyo3::{pyclass, PyErr};
+use serde::{Serialize, Deserialize};
+
+/// A currency identified by 3-ascii ISO code.
+#[pyclass(module = "rateslib.rs")]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub struct Ccy {
+    pub(crate) name: Intern<String>,
+}
+
+impl Ccy {
+    /// Constructs a new `Ccy`.
+    ///
+    /// Use **only** 3-ascii names. e.g. *"usd"*, aligned with ISO representation. `name` is converted
+    /// to lowercase to promote performant equality between "USD" and "usd".
+    ///
+    /// Panics if `name` is not 3 bytes in length.
+    pub fn try_new(name: &str) -> Result<Self, PyErr> {
+        let ccy: String = name.to_string().to_lowercase();
+        if ccy.len() != 3 {
+            return Err(PyValueError::new_err(
+                "`Ccy` must be 3 ascii character in length, e.g. 'usd'.",
+            ));
+        }
+        Ok(Ccy {
+            name: Intern::new(ccy),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ccy_creation() {
+        let a = Ccy::try_new("usd").unwrap();
+        let b = Ccy::try_new("USD").unwrap();
+        assert_eq!(a, b)
+    }
+
+    #[test]
+    fn ccy_creation_error() {
+        match Ccy::try_new("FOUR") {
+            Ok(_) => assert!(false),
+            Err(_) => assert!(true),
+        }
+    }
+}

--- a/src/fx/rates/fxpair.rs
+++ b/src/fx/rates/fxpair.rs
@@ -32,6 +32,7 @@ impl fmt::Display for FXPair {
 }
 
 mod tests {
+    use super::*;
     #[test]
     fn fxpair_creation() {
         let a = FXPair::try_new("usd", "eur").unwrap();

--- a/src/fx/rates/fxpair.rs
+++ b/src/fx/rates/fxpair.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 use pyo3::exceptions::PyValueError;
-use pyo3::{pyclass, PyErr};
+use pyo3::{PyErr};
 use serde::{Serialize, Deserialize};
 use crate::fx::rates::ccy::Ccy;
 
@@ -32,8 +32,6 @@ impl fmt::Display for FXPair {
 }
 
 mod tests {
-    use super::*;
-
     #[test]
     fn fxpair_creation() {
         let a = FXPair::try_new("usd", "eur").unwrap();

--- a/src/fx/rates/fxpair.rs
+++ b/src/fx/rates/fxpair.rs
@@ -1,0 +1,51 @@
+use std::fmt;
+use pyo3::exceptions::PyValueError;
+use pyo3::{pyclass, PyErr};
+use serde::{Serialize, Deserialize};
+use crate::fx::rates::ccy::Ccy;
+
+/// A container of a two-pair `Ccy` cross.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct FXPair(
+    pub(crate) Ccy,
+    pub(crate) Ccy
+);
+
+impl FXPair {
+    /// Constructs a new `FXPair`, as a combination of two distinct `Ccy`s.
+    pub fn try_new(lhs: &str, rhs: &str) -> Result<Self, PyErr> {
+        let lhs_ = Ccy::try_new(lhs)?;
+        let rhs_ = Ccy::try_new(rhs)?;
+        if lhs_ == rhs_ {
+            return Err(PyValueError::new_err(
+                "`FXPair` must be created from two distinct currencies, not same.",
+            ));
+        }
+        Ok(FXPair(lhs_, rhs_))
+    }
+}
+
+impl fmt::Display for FXPair {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}{}", self.0.name, self.1.name)
+    }
+}
+
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fxpair_creation() {
+        let a = FXPair::try_new("usd", "eur").unwrap();
+        let b = FXPair::try_new("USD", "EUR").unwrap();
+        assert_eq!(a, b)
+    }
+
+    #[test]
+    fn fxpair_creation_error() {
+        match FXPair::try_new("usd", "USD") {
+            Ok(_) => assert!(false),
+            Err(_) => assert!(true),
+        }
+    }
+}

--- a/src/fx/rates/fxpair.rs
+++ b/src/fx/rates/fxpair.rs
@@ -31,8 +31,10 @@ impl fmt::Display for FXPair {
     }
 }
 
+#[cfg(test)]
 mod tests {
     use super::*;
+
     #[test]
     fn fxpair_creation() {
         let a = FXPair::try_new("usd", "eur").unwrap();

--- a/src/fx/rates/fxrate.rs
+++ b/src/fx/rates/fxrate.rs
@@ -1,0 +1,39 @@
+use pyo3::{pyclass, PyErr};
+use serde::{Serialize, Deserialize};
+use chrono::NaiveDateTime;
+use crate::fx::rates::fxpair::FXPair;
+use crate::dual::dual_py::DualsOrF64;
+
+/// An FX rate containing `FXPair`, `rate` and `settlement` info.
+#[pyclass(module = "rateslib.rs")]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FXRate {
+    pub(crate) pair: FXPair,
+    pub(crate) rate: DualsOrF64,
+    pub(crate) settlement: Option<NaiveDateTime>,
+}
+
+impl FXRate {
+    pub fn try_new(
+        lhs: &str,
+        rhs: &str,
+        rate: DualsOrF64,
+        settlement: Option<NaiveDateTime>,
+    ) -> Result<Self, PyErr> {
+        Ok(FXRate {
+            pair: FXPair::try_new(lhs, rhs)?,
+            rate,
+            settlement,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fxrate_creation() {
+        FXRate::try_new("usd", "eur", DualsOrF64::F64(1.20), None).unwrap();
+    }
+}

--- a/src/fx/rates/fxrate.rs
+++ b/src/fx/rates/fxrate.rs
@@ -2,7 +2,7 @@ use pyo3::{pyclass, PyErr};
 use serde::{Serialize, Deserialize};
 use chrono::NaiveDateTime;
 use crate::fx::rates::fxpair::FXPair;
-use crate::dual::dual_py::DualsOrF64;
+use crate::dual::dual::DualsOrF64;
 
 /// An FX rate containing `FXPair`, `rate` and `settlement` info.
 #[pyclass(module = "rateslib.rs")]

--- a/src/fx/rates/mod.rs
+++ b/src/fx/rates/mod.rs
@@ -470,4 +470,25 @@ mod tests {
             _ => panic!("failure"),
         }
     }
+
+    #[test]
+    fn second_order_gradients_on_set_order() {
+        let mut fxr = FXRates::try_new(
+            vec![
+                FXRate::try_new("usd", "nok", DualsOrF64::F64(10.0), None).unwrap(),
+                FXRate::try_new("eur", "nok", DualsOrF64::F64(8.0), None).unwrap(),
+            ],
+            None,
+        ).unwrap();
+        let _ = fxr.set_ad_order(ADOrder::Two);
+        let d1 = Dual2::new(10.0, vec!["fx_usdnok".to_string()]);
+        let d2 = Dual2::new(8.0, vec!["fx_eurnok".to_string()]);
+        let d3 = d1 / d2;
+        let rate: Dual2 = fxr.rate(
+            &Ccy::try_new("usd").unwrap(),
+            &Ccy::try_new("eur").unwrap()
+        ).unwrap().into();
+        assert_eq!(d3, rate)
+    }
+
 }

--- a/src/fx/rates/mod.rs
+++ b/src/fx/rates/mod.rs
@@ -319,7 +319,7 @@ where for<'a> &'a T: Mul<&'a T, Output = T>,
 /// Creates an FX Array with the sparse graph network algorithm defining Dual variables directly.
 fn create_fx_array(currencies: &IndexSet<Ccy>, fx_rates: &[FXRate], ad: ADOrder) -> Result<FXArray, PyErr> {
     let fx_pairs: Vec<FXPair> = fx_rates.iter().map(|x| x.pair).collect();
-    let vars: Vec<String> = fx_pairs.iter().map(|x| format!("{}", x)).collect();
+    let vars: Vec<String> = fx_pairs.iter().map(|x| format!("fx_{}", x)).collect();
     let mut edges = create_initial_edges(currencies, &fx_pairs);
     match ad {
         ADOrder::Zero => {

--- a/src/fx/rates/mod.rs
+++ b/src/fx/rates/mod.rs
@@ -324,19 +324,19 @@ fn create_fx_array(currencies: &IndexSet<Ccy>, fx_rates: &[FXRate], ad: ADOrder)
     let fx_rates_: Vec<DualsOrF64> = fx_rates.iter().enumerate().map(|(i,x)| remap_rate(&x.rate, vec![vars[i].clone()], ad)).collect();
     match ad {
         ADOrder::Zero => {
-            let fx_rates__: Vec<f64> = fx_rates_.iter().map(|x| f64::from(x)).collect();
+            let fx_rates__: Vec<f64> = fx_rates_.iter().map(f64::from).collect();
             let mut fx_array_: Array2<f64> = create_initial_fx_array(currencies, &fx_pairs, &fx_rates__);
             let _ = mut_arrays_remaining_elements(fx_array_.view_mut(), edges.view_mut(), HashSet::new())?;
             Ok(FXArray::F64(fx_array_))
         }
         ADOrder::One => {
-            let fx_rates__: Vec<Dual> = fx_rates_.iter().enumerate().map(|(i,x)| Dual::from(x)).collect();
+            let fx_rates__: Vec<Dual> = fx_rates_.iter().map(Dual::from).collect();
             let mut fx_array_: Array2<Dual> = create_initial_fx_array(currencies, &fx_pairs, &fx_rates__);
             let _ = mut_arrays_remaining_elements(fx_array_.view_mut(), edges.view_mut(), HashSet::new())?;
             Ok(FXArray::Dual(fx_array_))
         }
         ADOrder::Two => {
-            let fx_rates__: Vec<Dual2> = fx_rates_.iter().enumerate().map(|(i,x)| Dual2::from(x)).collect();
+            let fx_rates__: Vec<Dual2> = fx_rates_.iter().map(Dual2::from).collect();
             let mut fx_array_: Array2<Dual2> = create_initial_fx_array(currencies, &fx_pairs, &fx_rates__);
             let _ = mut_arrays_remaining_elements(fx_array_.view_mut(), edges.view_mut(), HashSet::new())?;
             Ok(FXArray::Dual2(fx_array_))

--- a/src/fx/rates_py.rs
+++ b/src/fx/rates_py.rs
@@ -203,7 +203,7 @@ impl FXRates {
 
     #[pyo3(name = "set_ad_order")]
     fn set_ad_order_py(&mut self, ad: ADOrder) -> PyResult<()> {
-        let _ = self.set_ad_order(ad)?;
+        self.set_ad_order(ad)?;
         Ok(())
     }
 

--- a/src/fx/rates_py.rs
+++ b/src/fx/rates_py.rs
@@ -1,16 +1,16 @@
 //! Wrapper module to export Rust FX rate data types to Python using pyo3 bindings.
 
-use crate::dual::dual::DualsOrF64;
+use crate::dual::dual::{DualsOrF64, ADOrder};
 use crate::fx::rates::{Ccy, FXArray, FXRate, FXRates};
+use ndarray::Axis;
 use chrono::prelude::*;
 use pyo3::prelude::*;
 // use std::collections::HashMap;
-use crate::json::json_py::DeserializedObj;
-use ndarray::Axis;
 use pyo3::exceptions::PyValueError;
 // use pyo3::exceptions::PyValueError;
 // use pyo3::types::PyFloat;
 use crate::json::JSON;
+use crate::json::json_py::DeserializedObj;
 
 #[pymethods]
 impl Ccy {
@@ -201,10 +201,11 @@ impl FXRates {
         self.update(fx_rates)
     }
 
-    // #[pyo3(name = "set_ad_order")]
-    // fn set_ad_order_py(&mut self, ad: usize) {
-    //     self.set_ad_order(ad)
-    // }
+    #[pyo3(name = "set_ad_order")]
+    fn set_ad_order_py(&mut self, ad: ADOrder) -> PyResult<()> {
+        let _ = self.set_ad_order(ad)?;
+        Ok(())
+    }
 
     // JSON
     #[pyo3(name = "to_json")]

--- a/src/fx/rates_py.rs
+++ b/src/fx/rates_py.rs
@@ -1,6 +1,6 @@
 //! Wrapper module to export Rust FX rate data types to Python using pyo3 bindings.
 
-use crate::dual::dual_py::DualsOrF64;
+use crate::dual::dual::DualsOrF64;
 use crate::fx::rates::{Ccy, FXArray, FXRate, FXRates};
 use chrono::prelude::*;
 use pyo3::prelude::*;
@@ -201,10 +201,10 @@ impl FXRates {
         self.update(fx_rates)
     }
 
-    #[pyo3(name = "set_ad_order")]
-    fn set_ad_order_py(&mut self, ad: usize) {
-        self.set_ad_order(ad)
-    }
+    // #[pyo3(name = "set_ad_order")]
+    // fn set_ad_order_py(&mut self, ad: usize) {
+    //     self.set_ad_order(ad)
+    // }
 
     // JSON
     #[pyo3(name = "to_json")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,8 @@ use calendars::calendar::{Cal, Modifier, RollDay, UnionCal};
 use calendars::calendar_py::get_calendar_by_name_py;
 
 pub mod fx;
-use fx::rates::{Ccy, FXRate, FXRates};
+use fx::rates::ccy::Ccy;
+use fx::rates::{FXRate, FXRates};
 
 #[pymodule]
 fn rs(m: &Bound<'_, PyModule>) -> PyResult<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ use crate::json::json_py::from_json_py;
 use pyo3::prelude::*;
 
 pub mod dual;
-use dual::dual::{Dual, Dual2};
+use dual::dual::{Dual, Dual2, ADOrder};
 use dual::linalg_py::{dsolve1_py, dsolve2_py, fdsolve1_py, fdsolve2_py};
 
 pub mod splines;
@@ -42,6 +42,7 @@ fn rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Automatic Differentiation
     m.add_class::<Dual>()?;
     m.add_class::<Dual2>()?;
+    m.add_class::<ADOrder>()?;
     m.add_function(wrap_pyfunction!(dsolve1_py, m)?)?;
     m.add_function(wrap_pyfunction!(dsolve2_py, m)?)?;
     m.add_function(wrap_pyfunction!(fdsolve1_py, m)?)?;

--- a/src/splines/spline_py.rs
+++ b/src/splines/spline_py.rs
@@ -1,5 +1,4 @@
-use crate::dual::dual::{Dual, Dual2};
-use crate::dual::dual_py::DualsOrF64;
+use crate::dual::dual::{Dual, Dual2, DualsOrF64};
 use crate::splines::spline_f64::{bspldnev_single_f64, bsplev_single_f64, PPSpline};
 use std::cmp::PartialEq;
 

--- a/tests/test_fx.py
+++ b/tests/test_fx.py
@@ -174,6 +174,17 @@ def test_set_ad_order():
         fxr._set_ad_order("bad arg")
 
 
+def test_set_ad_order_second_order_gradients():
+    fxr = FXRates({"usdnok": 10.0})
+
+    fxr._set_ad_order(2)
+    assert fxr._ad == 2
+    assert type(fxr.fx_vector[0]) is Dual2
+    assert type(fxr.fx_vector[1]) is Dual2
+    assert np.isclose(fxr.fx_array[1, 0].dual, np.array([-0.01]))  # calculated analytically from USDNOK: 10.0
+    assert np.isclose(fxr.fx_array[1, 0].dual2, np.array([[0.001]]))  # calculated analytically
+
+
 @pytest.fixture()
 def usdusd():
     nodes = {dt(2022, 1, 1): 1.00, dt(2022, 4, 1): 0.99}

--- a/tests/test_fx.py
+++ b/tests/test_fx.py
@@ -175,6 +175,8 @@ def test_set_ad_order():
 
 
 def test_set_ad_order_second_order_gradients():
+    # test ensures that the FX Array is consecutively constructed passing correct second order gradients.
+    # Versions <1.3.0 failed to correctly handle this becuase they simply upcast the FX rates vector.
     fxr = FXRates({"usdnok": 10.0, "eurnok": 8.0})
 
     un = Dual2(10, ["fx_usdnok"], [], [])

--- a/tests/test_fx.py
+++ b/tests/test_fx.py
@@ -170,7 +170,7 @@ def test_set_ad_order():
     assert fxr.fx_vector[0] == 1.0
     assert fxr.fx_vector[1] == 10.0
 
-    with pytest.raises(TypeError, match="argument 'ad': 'str' object cannot be"):
+    with pytest.raises(ValueError, match="Order for AD can only be in {0,1,2}"):
         fxr._set_ad_order("bad arg")
 
 


### PR DESCRIPTION
NOTES:

This PR also restructred some of the FXrates code into separate modules for easier visibility and testing.

This PR also created conversions for Dual variables and the DualsOrF64 enum.