### PR TITLE
REF: prescribe math operations for DualsOrF64 

### DIFF
--- a/src/dual/dual.rs
+++ b/src/dual/dual.rs
@@ -40,6 +40,7 @@ pub struct Dual2 {
     pub(crate) dual2: Array2<f64>,
 }
 
+/// Container for the three core numeric types; `f64`, `Dual` and `Dual2`
 #[derive(Debug, Clone, PartialEq, PartialOrd, FromPyObject, Serialize, Deserialize)]
 pub enum DualsOrF64 {
     Dual(Dual),

--- a/src/dual/dual.rs
+++ b/src/dual/dual.rs
@@ -41,7 +41,7 @@ pub struct Dual2 {
 }
 
 /// Container for the three core numeric types; `f64`, `Dual` and `Dual2`
-#[derive(Debug, Clone, PartialEq, PartialOrd, FromPyObject, Serialize, Deserialize)]
+#[derive(Debug, Clone, FromPyObject, Serialize, Deserialize)]
 pub enum DualsOrF64 {
     Dual(Dual),
     Dual2(Dual2),

--- a/src/dual/dual.rs
+++ b/src/dual/dual.rs
@@ -12,6 +12,7 @@
 //!
 
 pub use crate::dual::dual_ops::math_funcs::MathFuncs;
+pub use crate::dual::dual_ops::field_ops::FieldOps;
 pub use crate::dual::dual_ops::convert::{set_order, set_order_clone};
 use indexmap::set::IndexSet;
 use ndarray::{Array, Array1, Array2, Axis};

--- a/src/dual/dual_ops/add.rs
+++ b/src/dual/dual_ops/add.rs
@@ -1,4 +1,4 @@
-use crate::dual::dual::{Dual, Dual2, Vars, VarsRelationship};
+use crate::dual::dual::{Dual, Dual2, Vars, VarsRelationship, DualsOrF64};
 use auto_ops::{impl_op_ex, impl_op_ex_commutative};
 use std::sync::Arc;
 
@@ -41,6 +41,21 @@ impl_op_ex!(+ |a: &Dual2, b: &Dual2| -> Dual2 {
                 dual2: &x.dual2 + &y.dual2,
                 vars: Arc::clone(&x.vars)}
         }
+    }
+});
+
+// Add for DualsOrF64
+impl_op_ex!(+ |a: &DualsOrF64, b: &DualsOrF64| -> DualsOrF64 {
+    match (a,b) {
+        (DualsOrF64::F64(f), DualsOrF64::F64(f2)) => DualsOrF64::F64(f + f2),
+        (DualsOrF64::F64(f), DualsOrF64::Dual(d2)) => DualsOrF64::Dual(f + d2),
+        (DualsOrF64::F64(f), DualsOrF64::Dual2(d2)) => DualsOrF64::Dual2(f + d2),
+        (DualsOrF64::Dual(d), DualsOrF64::F64(f2)) => DualsOrF64::Dual(d + f2),
+        (DualsOrF64::Dual(d), DualsOrF64::Dual(d2)) => DualsOrF64::Dual(d + d2),
+        (DualsOrF64::Dual(_), DualsOrF64::Dual2(_)) => panic!("Cannot mix dual types: Dual + Dual2"),
+        (DualsOrF64::Dual2(d), DualsOrF64::F64(f2)) => DualsOrF64::Dual2(d + f2),
+        (DualsOrF64::Dual2(_), DualsOrF64::Dual(_)) => panic!("Cannot mix dual types: Dual2 + Dual"),
+        (DualsOrF64::Dual2(d), DualsOrF64::Dual2(d2)) => DualsOrF64::Dual2(d + d2),
     }
 });
 
@@ -135,5 +150,22 @@ mod tests {
         .unwrap();
         let result = d1 + d2;
         assert_eq!(result, expected)
+    }
+
+    #[test]
+    fn test_enum() {
+        let f = DualsOrF64::F64(2.0);
+        let d = DualsOrF64::Dual(Dual::new(3.0, vec!["x".to_string()]));
+        assert_eq!(&f+&d, DualsOrF64::Dual(Dual::new(5.0, vec!["x".to_string()])));
+
+        assert_eq!(&d+&d, DualsOrF64::Dual(Dual::try_new(6.0, vec!["x".to_string()], vec![2.0]).unwrap()));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_enum_panic() {
+        let d = DualsOrF64::Dual2(Dual2::new(2.0, vec!["y".to_string()]));
+        let d2 = DualsOrF64::Dual(Dual::new(3.0, vec!["x".to_string()]));
+        let r = d + d2;
     }
 }

--- a/src/dual/dual_ops/add.rs
+++ b/src/dual/dual_ops/add.rs
@@ -166,6 +166,6 @@ mod tests {
     fn test_enum_panic() {
         let d = DualsOrF64::Dual2(Dual2::new(2.0, vec!["y".to_string()]));
         let d2 = DualsOrF64::Dual(Dual::new(3.0, vec!["x".to_string()]));
-        let r = d + d2;
+        let _ = d + d2;
     }
 }

--- a/src/dual/dual_ops/div.rs
+++ b/src/dual/dual_ops/div.rs
@@ -168,7 +168,7 @@ mod tests {
     fn test_enum_panic() {
         let d = DualsOrF64::Dual2(Dual2::new(2.0, vec!["y".to_string()]));
         let d2 = DualsOrF64::Dual(Dual::new(3.0, vec!["x".to_string()]));
-        let r = d / d2;
+        let _ = d / d2;
     }
 
 }

--- a/src/dual/dual_ops/eq.rs
+++ b/src/dual/dual_ops/eq.rs
@@ -69,6 +69,22 @@ impl PartialEq<Dual2> for Dual2 {
     }
 }
 
+impl PartialEq<DualsOrF64> for DualsOrF64 {
+    fn eq(&self, other: &DualsOrF64) -> bool {
+        match (self, other) {
+            (DualsOrF64::F64(f), DualsOrF64::F64(f2)) => f == f2,
+            (DualsOrF64::F64(f), DualsOrF64::Dual(d2)) => f == d2,
+            (DualsOrF64::F64(f), DualsOrF64::Dual2(d2)) => f == d2,
+            (DualsOrF64::Dual(d), DualsOrF64::F64(f2)) => d == f2,
+            (DualsOrF64::Dual(d), DualsOrF64::Dual(d2)) => d == d2,
+            (DualsOrF64::Dual(_), DualsOrF64::Dual2(_)) => panic!("Cannot mix dual types: Dual == Dual2"),
+            (DualsOrF64::Dual2(d), DualsOrF64::F64(f2)) => d == f2,
+            (DualsOrF64::Dual2(_), DualsOrF64::Dual(_)) => panic!("Cannot mix dual types: Dual2 == Dual"),
+            (DualsOrF64::Dual2(d), DualsOrF64::Dual2(d2)) => d == d2,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -179,5 +195,13 @@ mod tests {
         let f = DualsOrF64::F64(2.5_f64);
         let d = DualsOrF64::Dual(Dual::new(2.5_f64, vec![]));
         assert_eq!(f, d);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_cross_enum_eq_error() {
+        let d2 = DualsOrF64::Dual2(Dual2::new(2.5_f64, vec![]));
+        let d = DualsOrF64::Dual(Dual::new(2.5_f64, vec![]));
+        assert_eq!(d2, d);
     }
 }

--- a/src/dual/dual_ops/eq.rs
+++ b/src/dual/dual_ops/eq.rs
@@ -173,4 +173,11 @@ mod tests {
         let d2 = DualsOrF64::Dual(Dual::new(2.0, vec!["x".to_string()]));
         assert_eq!(d, d2)
     }
+
+    #[test]
+    fn test_cross_enum_eq() {
+        let f = DualsOrF64::F64(2.5_f64);
+        let d = DualsOrF64::Dual(Dual::new(2.5_f64, vec![]));
+        assert_eq!(f, d);
+    }
 }

--- a/src/dual/dual_ops/eq.rs
+++ b/src/dual/dual_ops/eq.rs
@@ -1,4 +1,4 @@
-use crate::dual::dual::{Dual, Dual2, Vars, VarsRelationship};
+use crate::dual::dual::{Dual, Dual2, Vars, VarsRelationship, DualsOrF64};
 
 /// Measures value equivalence of `Dual`.
 ///
@@ -158,5 +158,19 @@ mod tests {
             )
             .unwrap()
         );
+    }
+
+    #[test]
+    fn test_enum_ne() {
+        let d = DualsOrF64::Dual(Dual::new(2.0, vec!["x".to_string()]));
+        let d2 = DualsOrF64::Dual(Dual::new(3.0, vec!["x".to_string()]));
+        assert_ne!(d, d2)
+    }
+
+    #[test]
+    fn test_enum() {
+        let d = DualsOrF64::Dual(Dual::new(2.0, vec!["x".to_string()]));
+        let d2 = DualsOrF64::Dual(Dual::new(2.0, vec!["x".to_string()]));
+        assert_eq!(d, d2)
     }
 }

--- a/src/dual/dual_ops/field_ops.rs
+++ b/src/dual/dual_ops/field_ops.rs
@@ -1,4 +1,4 @@
-use crate::dual::dual::{Dual, Dual2};
+use crate::dual::dual::{Dual, Dual2, DualsOrF64};
 use std::ops::{Add, Div, Mul, Sub};
 
 pub trait FieldOps<T>:
@@ -12,7 +12,7 @@ impl<'a, T: 'a> FieldOps<T> for &'a T where
 impl FieldOps<Dual> for Dual {}
 impl FieldOps<Dual2> for Dual2 {}
 impl FieldOps<f64> for f64 {}
-
+impl FieldOps<DualsOrF64> for DualsOrF64 {}
 
 mod tests {
     use crate::dual::dual_ops::field_ops::FieldOps;

--- a/src/dual/dual_ops/field_ops.rs
+++ b/src/dual/dual_ops/field_ops.rs
@@ -14,6 +14,7 @@ impl FieldOps<Dual2> for Dual2 {}
 impl FieldOps<f64> for f64 {}
 impl FieldOps<DualsOrF64> for DualsOrF64 {}
 
+#[cfg(test)]
 mod tests {
     use super::*;
 

--- a/src/dual/dual_ops/field_ops.rs
+++ b/src/dual/dual_ops/field_ops.rs
@@ -15,7 +15,7 @@ impl FieldOps<f64> for f64 {}
 impl FieldOps<DualsOrF64> for DualsOrF64 {}
 
 mod tests {
-    use crate::dual::dual_ops::field_ops::FieldOps;
+    use super::*;
 
     #[test]
     fn test_fieldops() {

--- a/src/dual/dual_ops/from.rs
+++ b/src/dual/dual_ops/from.rs
@@ -181,7 +181,7 @@ mod tests {
     // }
 
     #[test]
-    fn from_f64_into_Dual() {
+    fn from_f64_into_dual() {
         let d = Dual::from(4.0_f64);
         assert_eq!(d, Dual::new(4.0_f64, vec![]));
 

--- a/src/dual/dual_ops/mod.rs
+++ b/src/dual/dual_ops/mod.rs
@@ -1,7 +1,7 @@
 mod add;
 mod div;
 mod eq;
-// pub mod field_ops;
+pub mod field_ops;
 mod from;
 pub mod math_funcs;
 mod mul;

--- a/src/dual/dual_ops/mul.rs
+++ b/src/dual/dual_ops/mul.rs
@@ -1,4 +1,4 @@
-use crate::dual::dual::{Dual, Dual2, Vars, VarsRelationship};
+use crate::dual::dual::{Dual, Dual2, Vars, VarsRelationship, DualsOrF64};
 use crate::dual::linalg_f64::fouter11_;
 use auto_ops::{impl_op_ex, impl_op_ex_commutative};
 use ndarray::Array2;
@@ -68,6 +68,21 @@ impl_op_ex!(*|a: &Dual2, b: &Dual2| -> Dual2 {
                 dual2,
             }
         }
+    }
+});
+
+// Mul for DualsOrF64
+impl_op_ex!(* |a: &DualsOrF64, b: &DualsOrF64| -> DualsOrF64 {
+    match (a,b) {
+        (DualsOrF64::F64(f), DualsOrF64::F64(f2)) => DualsOrF64::F64(f * f2),
+        (DualsOrF64::F64(f), DualsOrF64::Dual(d2)) => DualsOrF64::Dual(f * d2),
+        (DualsOrF64::F64(f), DualsOrF64::Dual2(d2)) => DualsOrF64::Dual2(f * d2),
+        (DualsOrF64::Dual(d), DualsOrF64::F64(f2)) => DualsOrF64::Dual(d * f2),
+        (DualsOrF64::Dual(d), DualsOrF64::Dual(d2)) => DualsOrF64::Dual(d * d2),
+        (DualsOrF64::Dual(_), DualsOrF64::Dual2(_)) => panic!("Cannot mix dual types: Dual * Dual2"),
+        (DualsOrF64::Dual2(d), DualsOrF64::F64(f2)) => DualsOrF64::Dual2(d * f2),
+        (DualsOrF64::Dual2(_), DualsOrF64::Dual(_)) => panic!("Cannot mix dual types: Dual2 * Dual"),
+        (DualsOrF64::Dual2(d), DualsOrF64::Dual2(d2)) => DualsOrF64::Dual2(d * d2),
     }
 });
 
@@ -162,5 +177,22 @@ mod tests {
         .unwrap();
         let result = d1 * d2;
         assert_eq!(result, expected)
+    }
+
+    #[test]
+    fn test_enum() {
+        let f = DualsOrF64::F64(2.0);
+        let d = DualsOrF64::Dual(Dual::new(3.0, vec!["x".to_string()]));
+        assert_eq!(&f*&d, DualsOrF64::Dual(Dual::try_new(6.0, vec!["x".to_string()], vec![2.0]).unwrap()));
+
+        assert_eq!(&d*&d, DualsOrF64::Dual(Dual::try_new(9.0, vec!["x".to_string()], vec![6.0]).unwrap()));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_enum_panic() {
+        let d = DualsOrF64::Dual2(Dual2::new(2.0, vec!["y".to_string()]));
+        let d2 = DualsOrF64::Dual(Dual::new(3.0, vec!["x".to_string()]));
+        let r = d * d2;
     }
 }

--- a/src/dual/dual_ops/mul.rs
+++ b/src/dual/dual_ops/mul.rs
@@ -193,6 +193,6 @@ mod tests {
     fn test_enum_panic() {
         let d = DualsOrF64::Dual2(Dual2::new(2.0, vec!["y".to_string()]));
         let d2 = DualsOrF64::Dual(Dual::new(3.0, vec!["x".to_string()]));
-        let r = d * d2;
+        let _ = d * d2;
     }
 }

--- a/src/dual/dual_ops/neg.rs
+++ b/src/dual/dual_ops/neg.rs
@@ -1,4 +1,4 @@
-use crate::dual::dual::{Dual, Dual2};
+use crate::dual::dual::{Dual, Dual2, DualsOrF64};
 use auto_ops::impl_op;
 use std::sync::Arc;
 
@@ -32,6 +32,24 @@ impl_op!(-|a: &Dual2| -> Dual2 {
         real: -a.real,
         dual: &a.dual * -1.0,
         dual2: &a.dual2 * -1.0,
+    }
+});
+
+// Neg for DualsOrF64
+impl_op!(- |a: &DualsOrF64| -> DualsOrF64 {
+    match a {
+        DualsOrF64::F64(f) => DualsOrF64::F64(-f),
+        DualsOrF64::Dual(d) => DualsOrF64::Dual(-d),
+        DualsOrF64::Dual2(d)=> DualsOrF64::Dual2(-d),
+    }
+});
+
+// Neg for DualsOrF64
+impl_op!(- |a: DualsOrF64| -> DualsOrF64 {
+    match a {
+        DualsOrF64::F64(f) => DualsOrF64::F64(-f),
+        DualsOrF64::Dual(d) => DualsOrF64::Dual(-d),
+        DualsOrF64::Dual2(d)=> DualsOrF64::Dual2(-d),
     }
 });
 
@@ -96,5 +114,13 @@ mod tests {
         assert!(d2.dual[0] == -2.0);
         assert!(d2.dual[1] == 1.4);
         assert!(d2.dual2[[1, 0]] == 1.0);
+    }
+
+    #[test]
+    fn test_enum() {
+        let f = DualsOrF64::F64(2.0);
+        let d = DualsOrF64::Dual(Dual::new(3.0, vec!["x".to_string()]));
+        assert_eq!(-f, DualsOrF64::F64(-2.0));
+        assert_eq!(-d, DualsOrF64::Dual(Dual::try_new(-3.0, vec!["x".to_string()], vec![-1.0]).unwrap()));
     }
 }

--- a/src/dual/dual_ops/num.rs
+++ b/src/dual/dual_ops/num.rs
@@ -1,4 +1,4 @@
-use crate::dual::dual::{Dual, Dual2};
+use crate::dual::dual::{Dual, Dual2, DualsOrF64};
 use num_traits::Num;
 
 impl Num for Dual {
@@ -13,5 +13,12 @@ impl Num for Dual2 {
     type FromStrRadixErr = String;
     fn from_str_radix(_src: &str, _radix: u32) -> Result<Self, Self::FromStrRadixErr> {
         Err("No implementation for sting radix for Dual2".to_string())
+    }
+}
+
+impl Num for DualsOrF64 {
+    type FromStrRadixErr = String;
+    fn from_str_radix(_src: &str, _radix: u32) -> Result<Self, Self::FromStrRadixErr> {
+        Err("No implementation for sting radix for DualsOrF64".to_string())
     }
 }

--- a/src/dual/dual_ops/one.rs
+++ b/src/dual/dual_ops/one.rs
@@ -1,4 +1,4 @@
-use crate::dual::dual::{Dual, Dual2};
+use crate::dual::dual::{Dual, Dual2, DualsOrF64};
 use num_traits::One;
 
 impl One for Dual {
@@ -10,6 +10,12 @@ impl One for Dual {
 impl One for Dual2 {
     fn one() -> Dual2 {
         Dual2::new(1.0, Vec::new())
+    }
+}
+
+impl One for DualsOrF64 {
+    fn one() -> DualsOrF64 {
+        DualsOrF64::F64(1.0_f64)
     }
 }
 
@@ -28,4 +34,11 @@ mod tests {
         let d = Dual2::one();
         assert_eq!(d, Dual2::new(1.0, vec![]));
     }
+
+    #[test]
+    fn one_enum() {
+        let d = DualsOrF64::one();
+        assert_eq!(d, DualsOrF64::F64(1.0));
+    }
+
 }

--- a/src/dual/dual_ops/ord.rs
+++ b/src/dual/dual_ops/ord.rs
@@ -118,7 +118,7 @@ mod tests {
         assert!(d1 <= d3);
     }
 
-        #[test]
+    #[test]
     fn test_enum() {
         let d = DualsOrF64::Dual(Dual::new(2.0, vec!["x".to_string()]));
         let d2 = DualsOrF64::Dual(Dual::new(3.0, vec!["x".to_string()]));

--- a/src/dual/dual_ops/ord.rs
+++ b/src/dual/dual_ops/ord.rs
@@ -1,4 +1,4 @@
-use crate::dual::dual::{Dual, Dual2};
+use crate::dual::dual::{Dual, Dual2, DualsOrF64};
 use std::cmp::Ordering;
 
 /// Compares `Dual` by `real` component only.
@@ -35,6 +35,22 @@ impl PartialOrd<Dual> for f64 {
 impl PartialOrd<Dual2> for f64 {
     fn partial_cmp(&self, other: &Dual2) -> Option<Ordering> {
         self.partial_cmp(&other.real)
+    }
+}
+
+impl PartialOrd<DualsOrF64> for DualsOrF64 {
+    fn partial_cmp(&self, other: &DualsOrF64) -> Option<Ordering> {
+        match (self, other) {
+            (DualsOrF64::F64(f), DualsOrF64::F64(f2)) => f.partial_cmp(f2),
+            (DualsOrF64::F64(f), DualsOrF64::Dual(d2)) => f.partial_cmp(d2),
+            (DualsOrF64::F64(f), DualsOrF64::Dual2(d2)) => f.partial_cmp(d2),
+            (DualsOrF64::Dual(d), DualsOrF64::F64(f2)) => d.partial_cmp(f2),
+            (DualsOrF64::Dual(d), DualsOrF64::Dual(d2)) => d.partial_cmp(d2),
+            (DualsOrF64::Dual(_), DualsOrF64::Dual2(_)) => panic!("Cannot mix dual types: Dual compare Dual2"),
+            (DualsOrF64::Dual2(d), DualsOrF64::F64(f2)) => d.partial_cmp(f2),
+            (DualsOrF64::Dual2(_), DualsOrF64::Dual(_)) => panic!("Cannot mix dual types: Dual2 compare Dual"),
+            (DualsOrF64::Dual2(d), DualsOrF64::Dual2(d2)) => d.partial_cmp(d2),
+        }
     }
 }
 
@@ -100,5 +116,27 @@ mod tests {
         let d3 = Dual2::try_new(1.0, vec!["v3".to_string()], vec![10.0], Vec::new()).unwrap();
         assert!(d1 >= d3);
         assert!(d1 <= d3);
+    }
+
+        #[test]
+    fn test_enum() {
+        let d = DualsOrF64::Dual(Dual::new(2.0, vec!["x".to_string()]));
+        let d2 = DualsOrF64::Dual(Dual::new(3.0, vec!["x".to_string()]));
+        assert!(d <= d2)
+    }
+
+    #[test]
+    fn test_cross_enum_eq() {
+        let f = DualsOrF64::F64(2.5_f64);
+        let d = DualsOrF64::Dual(Dual::new(3.5_f64, vec![]));
+        assert!(f <= d);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_cross_enum_eq_error() {
+        let d2 = DualsOrF64::Dual2(Dual2::new(2.5_f64, vec![]));
+        let d = DualsOrF64::Dual(Dual::new(2.5_f64, vec![]));
+        assert!(d <= d2);
     }
 }

--- a/src/dual/dual_ops/rem.rs
+++ b/src/dual/dual_ops/rem.rs
@@ -106,6 +106,6 @@ mod tests {
     fn test_enum_panic() {
         let d = DualsOrF64::Dual2(Dual2::new(2.0, vec!["y".to_string()]));
         let d2 = DualsOrF64::Dual(Dual::new(3.0, vec!["x".to_string()]));
-        let r = d % d2;
+        let _ = d % d2;
     }
 }

--- a/src/dual/dual_ops/rem.rs
+++ b/src/dual/dual_ops/rem.rs
@@ -1,4 +1,4 @@
-use crate::dual::dual::{Dual, Dual2};
+use crate::dual::dual::{Dual, Dual2, DualsOrF64};
 use auto_ops::impl_op_ex;
 use std::sync::Arc;
 
@@ -21,6 +21,21 @@ impl_op_ex!(% |a: &Dual, b: &Dual| -> Dual {
 impl_op_ex!(% |a: &Dual2, b: &Dual2| -> Dual2 {
     let d = f64::trunc(a.real / b.real);
     a - d * b
+});
+
+// Rem for DualsOrF64
+impl_op_ex!(% |a: &DualsOrF64, b: &DualsOrF64| -> DualsOrF64 {
+    match (a,b) {
+        (DualsOrF64::F64(f), DualsOrF64::F64(f2)) => DualsOrF64::F64(f % f2),
+        (DualsOrF64::F64(f), DualsOrF64::Dual(d2)) => DualsOrF64::Dual(f % d2),
+        (DualsOrF64::F64(f), DualsOrF64::Dual2(d2)) => DualsOrF64::Dual2(f % d2),
+        (DualsOrF64::Dual(d), DualsOrF64::F64(f2)) => DualsOrF64::Dual(d % f2),
+        (DualsOrF64::Dual(d), DualsOrF64::Dual(d2)) => DualsOrF64::Dual(d % d2),
+        (DualsOrF64::Dual(_), DualsOrF64::Dual2(_)) => panic!("Cannot mix dual types: Dual % Dual2"),
+        (DualsOrF64::Dual2(d), DualsOrF64::F64(f2)) => DualsOrF64::Dual2(d % f2),
+        (DualsOrF64::Dual2(_), DualsOrF64::Dual(_)) => panic!("Cannot mix dual types: Dual2 % Dual"),
+        (DualsOrF64::Dual2(d), DualsOrF64::Dual2(d2)) => DualsOrF64::Dual2(d % d2),
+    }
 });
 
 #[cfg(test)]
@@ -75,5 +90,22 @@ mod tests {
             result,
             Dual2::try_new(1.0, vec!["x".to_string()], vec![-2.0], vec![]).unwrap()
         );
+    }
+
+    #[test]
+    fn test_enum() {
+        let f = DualsOrF64::F64(4.0);
+        let d = DualsOrF64::Dual(Dual::new(3.0, vec!["x".to_string()]));
+        assert_eq!(&f%&d, DualsOrF64::Dual(Dual::try_new(1.0, vec!["x".to_string()], vec![-1.0]).unwrap()));
+
+        assert_eq!(&d%&d, DualsOrF64::Dual(Dual::try_new(0.0, vec!["x".to_string()], vec![0.0]).unwrap()));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_enum_panic() {
+        let d = DualsOrF64::Dual2(Dual2::new(2.0, vec!["y".to_string()]));
+        let d2 = DualsOrF64::Dual(Dual::new(3.0, vec!["x".to_string()]));
+        let r = d % d2;
     }
 }

--- a/src/dual/dual_ops/signed.rs
+++ b/src/dual/dual_ops/signed.rs
@@ -210,4 +210,12 @@ mod tests {
         let result = result.abs();
         assert_eq!(result, expected);
     }
+
+    #[test]
+    fn test_enum() {
+        let d = DualsOrF64::Dual(Dual::new(-2.5, vec!["x".to_string()]));
+        assert!(!d.is_positive());
+        assert!(d.is_negative());
+        assert_eq!(d.abs(), DualsOrF64::Dual(Dual::try_new(2.5, vec!["x".to_string()], vec![-1.0]).unwrap()));
+    }
 }

--- a/src/dual/dual_ops/signed.rs
+++ b/src/dual/dual_ops/signed.rs
@@ -1,4 +1,4 @@
-use crate::dual::dual::{Dual, Dual2};
+use crate::dual::dual::{Dual, Dual2, DualsOrF64};
 use num_traits::Signed;
 use std::sync::Arc;
 
@@ -85,6 +85,54 @@ impl Signed for Dual2 {
 
     fn is_negative(&self) -> bool {
         self.real.is_sign_negative()
+    }
+}
+
+impl Signed for DualsOrF64 {
+    fn abs(&self) -> Self {
+        match self {
+            DualsOrF64::F64(f) => DualsOrF64::F64(f.abs()),
+            DualsOrF64::Dual(d) => DualsOrF64::Dual(d.abs()),
+            DualsOrF64::Dual2(d) => DualsOrF64::Dual2(d.abs()),
+        }
+    }
+
+    fn abs_sub(&self, other: &Self) -> Self {
+        match (self, other) {
+            (DualsOrF64::F64(f), DualsOrF64::F64(f2)) => DualsOrF64::F64(f.abs_sub(f2)),
+            (DualsOrF64::F64(f), DualsOrF64::Dual(d2)) => DualsOrF64::Dual(Dual::new(*f, vec![]).abs_sub(d2)),
+            (DualsOrF64::F64(f), DualsOrF64::Dual2(d2)) => DualsOrF64::Dual2(Dual2::new(*f, vec![]).abs_sub(d2)),
+            (DualsOrF64::Dual(d), DualsOrF64::F64(f2)) => DualsOrF64::Dual(d.abs_sub(&Dual::new(*f2, vec![]))),
+            (DualsOrF64::Dual(d), DualsOrF64::Dual(d2)) => DualsOrF64::Dual(d.abs_sub(d2)),
+            (DualsOrF64::Dual(_), DualsOrF64::Dual2(_)) => panic!("Cannot mix dual types: Dual / Dual2"),
+            (DualsOrF64::Dual2(d), DualsOrF64::F64(f2)) => DualsOrF64::Dual2(d.abs_sub(&Dual2::new(*f2, vec![]))),
+            (DualsOrF64::Dual2(_), DualsOrF64::Dual(_)) => panic!("Cannot mix dual types: Dual2 / Dual"),
+            (DualsOrF64::Dual2(d), DualsOrF64::Dual2(d2)) => DualsOrF64::Dual2(d.abs_sub(d2)),
+        }
+    }
+
+    fn signum(&self) -> Self {
+        match self {
+            DualsOrF64::F64(f) => DualsOrF64::F64(f.signum()),
+            DualsOrF64::Dual(d) => DualsOrF64::Dual(d.signum()),
+            DualsOrF64::Dual2(d) => DualsOrF64::Dual2(d.signum()),
+        }
+    }
+
+    fn is_positive(&self) -> bool {
+        match self {
+            DualsOrF64::F64(f) => f.is_positive(),
+            DualsOrF64::Dual(d) => d.is_positive(),
+            DualsOrF64::Dual2(d) => d.is_positive(),
+        }
+    }
+
+    fn is_negative(&self) -> bool {
+        match self {
+            DualsOrF64::F64(f) => f.is_negative(),
+            DualsOrF64::Dual(d) => d.is_negative(),
+            DualsOrF64::Dual2(d) => d.is_negative(),
+        }
     }
 }
 

--- a/src/dual/dual_ops/sub.rs
+++ b/src/dual/dual_ops/sub.rs
@@ -1,4 +1,4 @@
-use crate::dual::dual::{Dual, Dual2, Vars, VarsRelationship};
+use crate::dual::dual::{Dual, Dual2, Vars, VarsRelationship, DualsOrF64};
 use auto_ops::impl_op_ex;
 use std::sync::Arc;
 
@@ -73,6 +73,21 @@ impl_op_ex!(-|a: &Dual2, b: &Dual2| -> Dual2 {
                 vars: Arc::clone(&x.vars),
             }
         }
+    }
+});
+
+// Add for DualsOrF64
+impl_op_ex!(- |a: &DualsOrF64, b: &DualsOrF64| -> DualsOrF64 {
+    match (a,b) {
+        (DualsOrF64::F64(f), DualsOrF64::F64(f2)) => DualsOrF64::F64(f - f2),
+        (DualsOrF64::F64(f), DualsOrF64::Dual(d2)) => DualsOrF64::Dual(f - d2),
+        (DualsOrF64::F64(f), DualsOrF64::Dual2(d2)) => DualsOrF64::Dual2(f - d2),
+        (DualsOrF64::Dual(d), DualsOrF64::F64(f2)) => DualsOrF64::Dual(d - f2),
+        (DualsOrF64::Dual(d), DualsOrF64::Dual(d2)) => DualsOrF64::Dual(d - d2),
+        (DualsOrF64::Dual(_), DualsOrF64::Dual2(_)) => panic!("Cannot mix dual types: Dual - Dual2"),
+        (DualsOrF64::Dual2(d), DualsOrF64::F64(f2)) => DualsOrF64::Dual2(d - f2),
+        (DualsOrF64::Dual2(_), DualsOrF64::Dual(_)) => panic!("Cannot mix dual types: Dual2 - Dual"),
+        (DualsOrF64::Dual2(d), DualsOrF64::Dual2(d2)) => DualsOrF64::Dual2(d - d2),
     }
 });
 
@@ -166,5 +181,22 @@ mod tests {
         .unwrap();
         let result = d1 - d2;
         assert_eq!(result, expected)
+    }
+
+    #[test]
+    fn test_enum() {
+        let f = DualsOrF64::F64(2.0);
+        let d = DualsOrF64::Dual(Dual::new(3.0, vec!["x".to_string()]));
+        assert_eq!(&f-&d, DualsOrF64::Dual(Dual::try_new(-1.0, vec!["x".to_string()], vec![-1.0]).unwrap()));
+
+        assert_eq!(&d-&d, DualsOrF64::Dual(Dual::try_new(0.0, vec!["x".to_string()], vec![0.0]).unwrap()));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_enum_panic() {
+        let d = DualsOrF64::Dual2(Dual2::new(2.0, vec!["y".to_string()]));
+        let d2 = DualsOrF64::Dual(Dual::new(3.0, vec!["x".to_string()]));
+        let r = d - d2;
     }
 }

--- a/src/dual/dual_ops/sub.rs
+++ b/src/dual/dual_ops/sub.rs
@@ -76,7 +76,7 @@ impl_op_ex!(-|a: &Dual2, b: &Dual2| -> Dual2 {
     }
 });
 
-// Add for DualsOrF64
+// Sub for DualsOrF64
 impl_op_ex!(- |a: &DualsOrF64, b: &DualsOrF64| -> DualsOrF64 {
     match (a,b) {
         (DualsOrF64::F64(f), DualsOrF64::F64(f2)) => DualsOrF64::F64(f - f2),

--- a/src/dual/dual_ops/sub.rs
+++ b/src/dual/dual_ops/sub.rs
@@ -197,6 +197,6 @@ mod tests {
     fn test_enum_panic() {
         let d = DualsOrF64::Dual2(Dual2::new(2.0, vec!["y".to_string()]));
         let d2 = DualsOrF64::Dual(Dual::new(3.0, vec!["x".to_string()]));
-        let r = d - d2;
+        let _ = d - d2;
     }
 }

--- a/src/dual/dual_ops/sum.rs
+++ b/src/dual/dual_ops/sum.rs
@@ -1,4 +1,4 @@
-use crate::dual::dual::{Dual, Dual2};
+use crate::dual::dual::{Dual, Dual2, DualsOrF64};
 use std::iter::Sum;
 
 impl Sum for Dual {
@@ -16,5 +16,30 @@ impl Sum for Dual2 {
         I: Iterator<Item = Dual2>,
     {
         iter.fold(Dual2::new(0.0, Vec::new()), |acc, x| acc + x)
+    }
+}
+
+impl Sum for DualsOrF64 {
+    fn sum<I>(iter: I) -> Self
+    where
+        I: Iterator<Item = DualsOrF64>,
+    {
+        iter.fold(DualsOrF64::F64(0.0_f64), |acc, x| acc + x)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_enum() {
+        let v = vec![
+            DualsOrF64::F64(2.5_f64),
+            DualsOrF64::Dual(Dual::new(1.5, vec!["x".to_string()])),
+            DualsOrF64::Dual(Dual::new(3.5, vec!["x".to_string()])),
+        ];
+        let s: DualsOrF64 = v.into_iter().sum();
+        assert_eq!(s, DualsOrF64::Dual(Dual::try_new(7.5, vec!["x".to_string()], vec![2.0]).unwrap()));
     }
 }

--- a/src/dual/dual_ops/zero.rs
+++ b/src/dual/dual_ops/zero.rs
@@ -1,4 +1,4 @@
-use crate::dual::dual::{Dual, Dual2};
+use crate::dual::dual::{Dual, Dual2, DualsOrF64};
 use num_traits::Zero;
 
 impl Zero for Dual {
@@ -21,6 +21,20 @@ impl Zero for Dual2 {
     }
 }
 
+impl Zero for DualsOrF64 {
+    fn zero() -> DualsOrF64 {
+        DualsOrF64::F64(0.0_f64)
+    }
+
+    fn is_zero(&self) -> bool {
+        match self {
+            DualsOrF64::F64(f) => *f == 0.0_f64,
+            DualsOrF64::Dual(d) => *d == Dual::new(0.0, vec![]),
+            DualsOrF64::Dual2(d) => *d == Dual2::new(0.0, vec![]),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -33,6 +47,12 @@ mod tests {
     #[test]
     fn is_zero2() {
         let d = Dual2::zero();
+        assert!(d.is_zero());
+    }
+
+    #[test]
+    fn is_zero_enum() {
+        let d = DualsOrF64::Dual2(Dual2::zero());
         assert!(d.is_zero());
     }
 }

--- a/src/dual/dual_py.rs
+++ b/src/dual/dual_py.rs
@@ -684,14 +684,14 @@ impl Dual2 {
     }
 
     // Pickling
-    pub fn __setstate__(&mut self, state: Bound<'_, PyBytes>) -> PyResult<()> {
+    fn __setstate__(&mut self, state: Bound<'_, PyBytes>) -> PyResult<()> {
         *self = deserialize(state.as_bytes()).unwrap();
         Ok(())
     }
-    pub fn __getstate__<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyBytes>> {
+    fn __getstate__<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyBytes>> {
         Ok(PyBytes::new_bound(py, &serialize(&self).unwrap()))
     }
-    pub fn __getnewargs__(&self) -> PyResult<(f64, Vec<String>, Vec<f64>, Vec<f64>)> {
+    fn __getnewargs__(&self) -> PyResult<(f64, Vec<String>, Vec<f64>, Vec<f64>)> {
         Ok((self.real, self.vars().iter().cloned().collect(), self.dual.to_vec(), self.dual2.clone().into_raw_vec()))
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,45 @@
-// use std::time::{Duration, SystemTime};
-use chrono::prelude::*;
-use chrono::Days;
+
+use std::time::SystemTime;
+use rateslib::dual::dual::{Dual, DualsOrF64, FieldOps};
+
+fn ops<T>(a: &T, b: &T) -> T
+where         T: FieldOps<T>,
+  for<'a> &'a T: FieldOps<T>
+{
+    &(&(&(a + b) - a) * b) / a
+}
 
 fn main() {
-    let list: Vec<f64> = (0..100).map(f64::from).collect();
+    let a0 = 2.5_f64;
+    let b0 = 3.5_f64;
+    let a1 = Dual::new(2.5_f64, vec!["x".to_string(), "y".to_string()]);
+    let b1 = Dual::new_from(&a1, 3.5_f64, vec!["x".to_string(), "y".to_string()]);
+    let a2 = DualsOrF64::Dual(a1.clone());
+    let b2 = DualsOrF64::Dual(b1.clone());
+    let a3 = DualsOrF64::F64(2.5_f64);
+    let b3 = DualsOrF64::F64(3.5_f64);
+
     let now = SystemTime::now();
-    let mut result = 0;
-    for i in 0..1000000 {
-        result = index_left(&list[..], &25_f64, None);
+
+    for i in 0..1000 {
+        let _ = ops(&a0, &b0);
     }
-    println!("{:.5?} seconds", now.elapsed());
-    println!("{}", result);
+    println!("{:.5?} time taken for f64", now.elapsed());
+
+    for i in 0..1000 {
+        let _ = ops(&a3, &b3);
+    }
+    println!("{:.5?} time taken for DualsOrF64 F64 wrapper", now.elapsed());
+
+    for i in 0..1000 {
+        let _ = ops(&a1, &b1);
+    }
+    println!("{:.5?} time taken for Dual", now.elapsed());
+
+    for i in 0..1000 {
+        let _ = ops(&a2, &b2);
+    }
+    println!("{:.5?} time taken for DualsOrF64 Dual wrapper", now.elapsed());
+
+
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,16 +3,12 @@ use chrono::prelude::*;
 use chrono::Days;
 
 fn main() {
-    //     let list: Vec<f64> = (0..100).map(f64::from).collect();
-    //     let now = SystemTime::now();
-    //     let mut result = 0;
-    //     for i in 0..1000000 {
-    //         result = index_left(&list[..], &25_f64, None);
-    //     }
-    //     println!("{:.5?} seconds", now.elapsed());
-    //     println!("{}", result);
-
-    let date = NaiveDateTime::parse_from_str("2015-09-05 00:00:00", "%Y-%m-%d %H:%M:%S").unwrap();
-    let date2 = date + Days::new(1);
-    println!("{:?}", date2)
+    let list: Vec<f64> = (0..100).map(f64::from).collect();
+    let now = SystemTime::now();
+    let mut result = 0;
+    for i in 0..1000000 {
+        result = index_left(&list[..], &25_f64, None);
+    }
+    println!("{:.5?} seconds", now.elapsed());
+    println!("{}", result);
 }


### PR DESCRIPTION
Includes the operations for coordinating a `DualsOrF64` enum:

- Add
- Sub
- Mul
- Div
- Neg
- Value PartialEq
- Rem
- One
- Zero
- Num
- Signed
- PartialOrd
- Sum
- FieldOps