### PR TITLE
Bug: raise Error for 1d schedule that does not have valid calendar and modifier combinations

### DIFF
--- a/docs/source/i_whatsnew.rst
+++ b/docs/source/i_whatsnew.rst
@@ -86,6 +86,10 @@ email contact, see `rateslib <https://rateslib.com>`_.
        fixings to account for DCFs, amended payment dates, and interpolated stubs. Requires
        a new ``disc_curve`` argument for proper discounting.
        (`470 <https://github.com/attack68/rateslib/pull/470>`_)
+   * - Bug
+     - No longer allow the creation of very short *Schedules* with holiday dates that
+       collapse to empty *Periods*.
+       (`484 <https://github.com/attack68/rateslib/pull/484>`_)
    * - Developers
      - *rateslib-rs* extension upgrades to using PyO3:0.22, nadarray:0.16, numpy:0.22.
        (`460 <https://github.com/attack68/rateslib/pull/460>`_)

--- a/python/rateslib/scheduling.py
+++ b/python/rateslib/scheduling.py
@@ -421,7 +421,9 @@ class Schedule:
                 self.calendar,
             )
             if not valid:
-                raise ValueError("date, stub and roll inputs are invalid")
+                return _raise_date_value_error(
+                    self.effective, self.termination, front_stub, back_stub, roll, self.calendar
+                )
             else:
                 self.ueffective = parsed_args["ueffective"]
                 self.utermination = parsed_args["utermination"]
@@ -440,7 +442,9 @@ class Schedule:
                 self.calendar,
             )
             if not valid:
-                raise ValueError("date, stub and roll inputs are invalid")
+                return _raise_date_value_error(
+                    self.effective, self.termination, front_stub, back_stub, roll, self.calendar
+                )
             else:
                 self.ueffective = self.effective
                 self.utermination = self.termination
@@ -465,7 +469,9 @@ class Schedule:
                 self.calendar,
             )
             if not valid:
-                raise ValueError("date, stub and roll inputs are invalid")
+                return _raise_date_value_error(
+                    self.effective, self.termination, front_stub, back_stub, roll, self.calendar
+                )
             else:
                 self.ueffective = parsed_args["ueffective"]
                 self.utermination = parsed_args["utermination"]
@@ -484,7 +490,9 @@ class Schedule:
                 self.calendar,
             )
             if not valid:
-                raise ValueError("date, stub and roll inputs are invalid")
+                return _raise_date_value_error(
+                    self.effective, self.termination, front_stub, back_stub, roll, self.calendar
+                )
             else:
                 # stub inference is not required, no stubs are necessary
                 self.ueffective = self.effective
@@ -510,7 +518,9 @@ class Schedule:
                 self.calendar,
             )
             if not valid:
-                raise ValueError("date, stub and roll inputs are invalid")
+                return _raise_date_value_error(
+                    self.effective, self.termination, front_stub, back_stub, roll, self.calendar
+                )
             else:
                 self.ueffective = parsed_args["ueffective"]
                 self.utermination = parsed_args["utermination"]
@@ -529,7 +539,9 @@ class Schedule:
                 self.calendar,
             )
             if not valid:
-                raise ValueError("date, stub and roll inputs are invalid")
+                return _raise_date_value_error(
+                    self.effective, self.termination, front_stub, back_stub, roll, self.calendar
+                )
             else:
                 self.ueffective = parsed_args["ueffective"]
                 self.utermination = self.termination
@@ -874,6 +886,8 @@ def _check_regular_swap(
 
     err_str = ""
     for _ueff, _uterm in product(_ueffectives, _uterminations):
+        if _ueff == _uterm:
+            continue # do not allow same date (avoids 1d periods GH484)
         ret = _check_unadjusted_regular_swap(_ueff, _uterm, frequency, eom, roll)
         if ret[0]:
             return ret
@@ -1507,6 +1521,16 @@ def _get_n_periods_in_regular(
         raise ValueError("Regular schedule not implied by `frequency` and dates.")
     return int(n_months / frequency_months)
 
+
+def _raise_date_value_error(effective, termination, front_stub, back_stub, roll, calendar):
+    raise ValueError(
+        "date, stub and roll inputs are invalid\n"
+        f"`effective`: {effective} (is business day? {calendar.is_bus_day(effective)})\n"
+        f"`front_stub`: {front_stub},\n"
+        f"`back_stub`: {back_stub},\n"
+        f"`termination`: {termination} (is business day? {calendar.is_bus_day(termination)})\n"
+        f"`roll`: {roll},\n"
+    )
 
 # Licence: Creative Commons - Attribution-NonCommercial-NoDerivatives 4.0 International
 # Commercial use of this code, and/or copying and redistribution is prohibited.

--- a/python/rateslib/scheduling.py
+++ b/python/rateslib/scheduling.py
@@ -1095,7 +1095,9 @@ def _infer_stub_date(
             }
         elif valid:
             # utermination aligns with ueffective then dead_too_short_period: GH484
-            return _raise_date_value_error(effective, termination, front_stub, back_stub, roll, calendar)
+            return _raise_date_value_error(
+                effective, termination, front_stub, back_stub, roll, calendar
+            )
         else:
             stub_ = _get_default_stub("FRONT", stub)
             front_stub = _get_unadjusted_stub_date(
@@ -1155,7 +1157,9 @@ def _infer_stub_date(
             }
         elif valid:
             # utermination aligns with ueffective then dead_too_short_period: GH484
-            return _raise_date_value_error(effective, termination, front_stub, back_stub, roll, calendar)
+            return _raise_date_value_error(
+                effective, termination, front_stub, back_stub, roll, calendar
+            )
         else:
             stub_ = _get_default_stub("BACK", stub)
             back_stub = _get_unadjusted_stub_date(
@@ -1537,6 +1541,7 @@ def _raise_date_value_error(effective, termination, front_stub, back_stub, roll,
         f"`termination`: {termination} (is business day? {calendar.is_bus_day(termination)})\n"
         f"`roll`: {roll},\n"
     )
+
 
 # Licence: Creative Commons - Attribution-NonCommercial-NoDerivatives 4.0 International
 # Commercial use of this code, and/or copying and redistribution is prohibited.

--- a/python/rateslib/scheduling.py
+++ b/python/rateslib/scheduling.py
@@ -886,8 +886,6 @@ def _check_regular_swap(
 
     err_str = ""
     for _ueff, _uterm in product(_ueffectives, _uterminations):
-        if _ueff == _uterm:
-            continue # do not allow same date (avoids 1d periods GH484)
         ret = _check_unadjusted_regular_swap(_ueff, _uterm, frequency, eom, roll)
         if ret[0]:
             return ret
@@ -1084,7 +1082,8 @@ def _infer_stub_date(
             roll,
             calendar,
         )
-        if valid:  # no front stub is required
+        if valid and parsed_args["utermination"] > parsed_args["ueffective"]:
+            # no front stub is required
             return True, {
                 "ueffective": parsed_args["ueffective"],
                 "utermination": parsed_args["utermination"],
@@ -1094,6 +1093,9 @@ def _infer_stub_date(
                 "frequency": parsed_args["frequency"],
                 "eom": parsed_args["eom"],
             }
+        elif valid:
+            # utermination aligns with ueffective then dead_too_short_period: GH484
+            return _raise_date_value_error(effective, termination, front_stub, back_stub, roll, calendar)
         else:
             stub_ = _get_default_stub("FRONT", stub)
             front_stub = _get_unadjusted_stub_date(
@@ -1140,7 +1142,8 @@ def _infer_stub_date(
             roll,
             calendar,
         )
-        if valid:  # no back stub is required
+        if valid and parsed_args["utermination"] > parsed_args["ueffective"]:
+            # no back stub is required
             return True, {
                 "ueffective": parsed_args["ueffective"],
                 "utermination": parsed_args["utermination"],
@@ -1150,6 +1153,9 @@ def _infer_stub_date(
                 "frequency": parsed_args["frequency"],
                 "eom": parsed_args["eom"],
             }
+        elif valid:
+            # utermination aligns with ueffective then dead_too_short_period: GH484
+            return _raise_date_value_error(effective, termination, front_stub, back_stub, roll, calendar)
         else:
             stub_ = _get_default_stub("BACK", stub)
             back_stub = _get_unadjusted_stub_date(

--- a/python/tests/test_instruments.py
+++ b/python/tests/test_instruments.py
@@ -1115,6 +1115,26 @@ class TestIRS:
         result = irs.fixings_table()
         assert isinstance(result, DataFrame)
 
+    def test_1d_instruments(self):
+        turns = Curve(
+            nodes={
+                dt(2024, 11, 11): 1.0,
+                dt(2025, 1, 1): 1.0,
+                dt(2025, 10, 1): 1.0,
+                dt(2026, 1, 1): 1.0,
+                dt(2027, 10, 1): 1.0,
+                dt(2028, 1, 1): 1.0,
+                dt(2054, 11, 16): 1.0,
+            },
+            calendar="stk",
+            convention="act360",
+            id="stibor3m_turns",
+        )
+        irs = IRS(dt(2025, 1, 1), "1d", spec="sek_irs", curves="stibor3m_turns")
+        irs.rate(turns)
+
+
+
 
 class TestIIRS:
     def test_index_base_none_populated(self, curve) -> None:

--- a/python/tests/test_instruments.py
+++ b/python/tests/test_instruments.py
@@ -1116,24 +1116,8 @@ class TestIRS:
         assert isinstance(result, DataFrame)
 
     def test_1d_instruments(self):
-        turns = Curve(
-            nodes={
-                dt(2024, 11, 11): 1.0,
-                dt(2025, 1, 1): 1.0,
-                dt(2025, 10, 1): 1.0,
-                dt(2026, 1, 1): 1.0,
-                dt(2027, 10, 1): 1.0,
-                dt(2028, 1, 1): 1.0,
-                dt(2054, 11, 16): 1.0,
-            },
-            calendar="stk",
-            convention="act360",
-            id="stibor3m_turns",
-        )
-        irs = IRS(dt(2025, 1, 1), "1d", spec="sek_irs", curves="stibor3m_turns")
-        irs.rate(turns)
-
-
+        with pytest.raises(ValueError, match="date, stub and roll inputs are invalid"):
+            IRS(dt(2025, 1, 1), "1d", spec="sek_irs")
 
 
 class TestIIRS:

--- a/python/tests/test_instruments.py
+++ b/python/tests/test_instruments.py
@@ -1116,6 +1116,7 @@ class TestIRS:
         assert isinstance(result, DataFrame)
 
     def test_1d_instruments(self):
+        # GH484
         with pytest.raises(ValueError, match="date, stub and roll inputs are invalid"):
             IRS(dt(2025, 1, 1), "1d", spec="sek_irs")
 


### PR DESCRIPTION
These type of swaps leave a null period, i.e. no valid dates, so raise better errors.