### PR TITLE
REF: `curve` handling in FloatPeriod `rate` and `npv` 

### DIFF
--- a/python/rateslib/periods.py
+++ b/python/rateslib/periods.py
@@ -929,7 +929,7 @@ class FloatPeriod(BasePeriod):
         :meth:`BasePeriod.npv()<rateslib.periods.BasePeriod.npv>`
         """
         disc_curve_: Curve | NoInput = _disc_maybe_from_curve(curve, disc_curve)
-        if not isinstance(disc_curve_, Curve) or curve is NoInput.blank:
+        if not isinstance(disc_curve_, Curve):
             raise TypeError("`curves` have not been supplied correctly.")
         if self.payment < disc_curve_.node_dates[0]:
             if local:
@@ -4160,10 +4160,10 @@ def _disc_maybe_from_curve(
     curve: Curve | NoInput | dict,
     disc_curve: Curve | NoInput,
 ) -> Curve | NoInput:
-    if disc_curve is NoInput.blank:
+    if isinstance(disc_curve, NoInput):
         if isinstance(curve, dict):
             raise ValueError("`disc_curve` cannot be inferred from a dictionary of curves.")
-        _: Curve = curve
+        _: Curve | NoInput = curve
     else:
         _ = disc_curve
     return _

--- a/python/tests/test_periods.py
+++ b/python/tests/test_periods.py
@@ -1701,10 +1701,9 @@ class TestFloatPeriod:
         result = period.npv(curve, local=True)
         assert result == {"usd": 0.0}
 
-    @pytest.mark.parametrize("curve", [
-        NoInput(0),
-        LineCurve({dt(2000, 1, 1): 2.0, dt(2001, 1, 1): 2.0})
-    ])
+    @pytest.mark.parametrize(
+        "curve", [NoInput(0), LineCurve({dt(2000, 1, 1): 2.0, dt(2001, 1, 1): 2.0})]
+    )
     @pytest.mark.parametrize("fixing_method", ["ibor", "rfr_payment_delay_avg"])
     @pytest.mark.parametrize("fixings", [3.0, NoInput(0)])
     def test_rate_optional_curve(self, fixings, fixing_method, curve) -> None:
@@ -1728,14 +1727,16 @@ class TestFloatPeriod:
             result = period.rate(curve)
             assert abs(result - 3.0) < 1e-8  # uses fixing
 
-    @pytest.mark.parametrize("fixings", [
-        [2.0, 2.0, 2.0],  # some unknown
-        [2.0] * 31  # exhaustive
-    ])
-    @pytest.mark.parametrize("curve", [
-        NoInput(0),
-        LineCurve({dt(2000, 1, 1): 2.0, dt(2001, 1, 1): 2.0})
-    ])
+    @pytest.mark.parametrize(
+        "fixings",
+        [
+            [2.0, 2.0, 2.0],  # some unknown
+            [2.0] * 31,  # exhaustive
+        ],
+    )
+    @pytest.mark.parametrize(
+        "curve", [NoInput(0), LineCurve({dt(2000, 1, 1): 2.0, dt(2001, 1, 1): 2.0})]
+    )
     def test_rate_optional_curve_rfr(self, curve, fixings) -> None:
         # GH530. Test RFR periods what happens when supply/not supply a Curve and fixings
         # are either exhaustive/ not exhaustive
@@ -1757,6 +1758,7 @@ class TestFloatPeriod:
         else:
             # it will conclude without fail.
             period.rate(curve)
+
 
 class TestFixedPeriod:
     def test_fixed_period_analytic_delta(self, curve, fxr) -> None:

--- a/python/tests/test_periods.py
+++ b/python/tests/test_periods.py
@@ -1706,7 +1706,7 @@ class TestFloatPeriod:
         LineCurve({dt(2000, 1, 1): 2.0, dt(2001, 1, 1): 2.0})
     ])
     @pytest.mark.parametrize("fixing_method", ["ibor", "rfr_payment_delay_avg"])
-    @pytest.mark.parametrize("fixings", [2.0, NoInput(0)])
+    @pytest.mark.parametrize("fixings", [3.0, NoInput(0)])
     def test_rate_optional_curve(self, fixings, fixing_method, curve) -> None:
         # GH530. Allow forecasting rates without necessarily providing curve if unnecessary
         period = FloatPeriod(
@@ -1721,9 +1721,12 @@ class TestFloatPeriod:
             # then no data to price
             with pytest.raises(ValueError, match="Must supply a valid `curve` for forec"):
                 period.rate(curve)
+        elif isinstance(fixings, NoInput):
+            result = period.rate(curve)
+            assert abs(result - 2.0) < 1e-8  # uses curve
         else:
             result = period.rate(curve)
-            assert abs(result - 2.0) < 1e-8
+            assert abs(result - 3.0) < 1e-8  # uses fixing
 
 class TestFixedPeriod:
     def test_fixed_period_analytic_delta(self, curve, fxr) -> None:

--- a/python/tests/test_periods.py
+++ b/python/tests/test_periods.py
@@ -1631,7 +1631,7 @@ class TestFloatPeriod:
             float_spread=0.0,
             stub=True,
         )
-        with pytest.raises(ValueError, match="Must supply a valid curve for forecasting"):
+        with pytest.raises(ValueError, match="Must supply a valid `curve` for forecasting"):
             period.rate({"rfr": curve})
 
     def test_ibor_stub_fixings_table(self) -> None:


### PR DESCRIPTION
setup tests for many cases.

The only case missing here is when exhaustive RFR fixings are provided as a list or a Series and a curve is not provided. Technically that period should still be capable of supplying a rate.