### PR TITLE
BUG: Fx instruments with sabr surface interp

### DIFF
--- a/python/rateslib/dual/newton.py
+++ b/python/rateslib/dual/newton.py
@@ -60,9 +60,9 @@ def newton_1dim(
     max_iter: int = 50,
     func_tol: float = 1e-14,
     conv_tol: float = 1e-9,
-    args: tuple[str | DualTypes, ...] = (),
-    pre_args: tuple[str | DualTypes, ...] = (),
-    final_args: tuple[str | DualTypes, ...] = (),
+    args: tuple[Any, ...] = (),
+    pre_args: tuple[Any, ...] = (),
+    final_args: tuple[Any, ...] = (),
     raise_on_fail: bool = True,
 ) -> dict[str, Any]:
     """
@@ -139,7 +139,7 @@ def newton_1dim(
     state = -1
 
     while i < max_iter:
-        f0, f1 = f(*(g0, *float_args, *pre_args))  # type: ignore[call-arg, arg-type]
+        f0, f1 = f(*(g0, *float_args, *pre_args))  # type: ignore[call-arg]
         i += 1
         g1 = g0 - f0 / f1
         if abs(f0) < func_tol:
@@ -160,12 +160,12 @@ def newton_1dim(
             return _solver_result(-1, i, g1, time() - t0, log=True, algo="newton_1dim")
 
     # # Final iteration method to preserve AD
-    f0, f1 = f(*(g1, *args, *final_args))  # type: ignore[call-arg, arg-type]
+    f0, f1 = f(*(g1, *args, *final_args))  # type: ignore[call-arg]
     if isinstance(f0, Dual | Dual2) or isinstance(f1, Dual | Dual2):
         i += 1
         g1 = g1 - f0 / f1
     if isinstance(f0, Dual2) or isinstance(f1, Dual2):
-        f0, f1 = f(*(g1, *args, *final_args))  # type: ignore[call-arg, arg-type]
+        f0, f1 = f(*(g1, *args, *final_args))  # type: ignore[call-arg]
         i += 1
         g1 = g1 - f0 / f1
 
@@ -206,9 +206,9 @@ def newton_ndim(
     max_iter: int = 50,
     func_tol: float = 1e-14,
     conv_tol: float = 1e-9,
-    args: tuple[str | DualTypes, ...] = (),
-    pre_args: tuple[str | DualTypes, ...] = (),
-    final_args: tuple[str | DualTypes, ...] = (),
+    args: tuple[Any, ...] = (),
+    pre_args: tuple[Any, ...] = (),
+    final_args: tuple[Any, ...] = (),
     raise_on_fail: bool = True,
 ) -> dict[str, Any]:
     r"""
@@ -281,7 +281,7 @@ def newton_ndim(
     state = -1
 
     while i < max_iter:
-        f0, f1 = f(*(g0_, *float_args, *pre_args))  # type: ignore[call-arg, arg-type]
+        f0, f1 = f(*(g0_, *float_args, *pre_args))  # type: ignore[call-arg]
         f0 = np.array(f0)[:, np.newaxis]
         f1 = np.array(f1)
 

--- a/python/rateslib/instruments/fx_volatility/vanilla.py
+++ b/python/rateslib/instruments/fx_volatility/vanilla.py
@@ -323,7 +323,10 @@ class FXOption(Sensitivities, Metrics, metaclass=ABCMeta):
         w_spot = curves_1[self._pricing.spot]
 
         # determine if _PricingMetrics.k can be set directly to a numeric value
-        if isinstance(self.kwargs["strike"], str) and self.kwargs["strike"].lower() in ["atm_forward", "atm_spot"]:
+        if isinstance(self.kwargs["strike"], str) and self.kwargs["strike"].lower() in [
+            "atm_forward",
+            "atm_spot",
+        ]:
             # then strike can be set directly as a calculated value
             method: str = self.kwargs["strike"].lower()
             if method == "atm_forward":

--- a/python/rateslib/instruments/fx_volatility/vanilla.py
+++ b/python/rateslib/instruments/fx_volatility/vanilla.py
@@ -365,6 +365,7 @@ class FXOption(Sensitivities, Metrics, metaclass=ABCMeta):
                 )
 
         # _PricingMetrics.k is completely specified
+        assert self._pricing.k is not None  # noqa: S101
         # Review section in book regarding Hyper-parameters and Solver interaction
         self.periods[0].strike = self._pricing.k
         # self._option_periods[0].strike = _dual_float(self._pricing.k)

--- a/python/rateslib/instruments/fx_volatility/vanilla.py
+++ b/python/rateslib/instruments/fx_volatility/vanilla.py
@@ -52,7 +52,7 @@ if TYPE_CHECKING:
 @dataclass
 class _PricingMetrics:
     vol: FXVolOption_
-    k: DualTypes
+    k: DualTypes | None
     delta_index: DualTypes | None
     spot: datetime
     t_e: DualTypes
@@ -288,9 +288,17 @@ class FXOption(Sensitivities, Metrics, metaclass=ABCMeta):
         fx: FX_,
         vol: FXVolOption_,
     ) -> None:
-        # If the strike for the option is not set directly it must be inferred
-        # and some of the pricing elements associated with this strike definition must
-        # be captured for use in subsequent formulae.
+        """
+        Set the strike, if necessary, and determine pricing metrics from the volatility objects.
+
+        The strike for the *OptionPeriod* is either; string or numeric.
+
+        If it is string, then a numeric strike must be determined with an associated vol.
+
+        If it is numeric then the volatility must be determined for the given strike.
+
+        Pricing elements are captured and cached so they can be used later by subsequent methods.
+        """
         fx_ = _validate_fx_as_forwards(fx)
         # vol_: FXVolOption = _validate_obj_not_no_input(vol, "vol")  # type: ignore[assignment]
         vol_ = vol
@@ -304,7 +312,7 @@ class FXOption(Sensitivities, Metrics, metaclass=ABCMeta):
 
         self._pricing = _PricingMetrics(
             vol=vol_,
-            k=self.kwargs["strike"],
+            k=None,
             delta_index=None,
             spot=fx_.pairs_settlement[self.kwargs["pair"]],
             t_e=self._option_periods[0]._t_to_expiry(eval_date),
@@ -314,16 +322,20 @@ class FXOption(Sensitivities, Metrics, metaclass=ABCMeta):
         w_deli = curves_1[self.kwargs["delivery"]]
         w_spot = curves_1[self._pricing.spot]
 
-        if isinstance(self.kwargs["strike"], str):
-            method = self.kwargs["strike"].lower()
-
+        # determine if _PricingMetrics.k can be set directly to a numeric value
+        if isinstance(self.kwargs["strike"], str) and self.kwargs["strike"].lower() in ["atm_forward", "atm_spot"]:
+            # then strike can be set directly as a calculated value
+            method: str = self.kwargs["strike"].lower()
             if method == "atm_forward":
                 self._pricing.k = fx_.rate(self.kwargs["pair"], self.kwargs["delivery"])
-
             elif method == "atm_spot":
                 self._pricing.k = fx_.rate(self.kwargs["pair"], self._pricing.spot)
-
-            elif method == "atm_delta":
+        elif not isinstance(self.kwargs["strike"], str):
+            self._pricing.k = self.kwargs["strike"]
+        else:
+            # strike on the option will either a delta % or ATM delta, as string
+            method = self.kwargs["strike"].lower()
+            if method == "atm_delta":
                 self._pricing.k, self._pricing.delta_index = self._option_periods[
                     0
                 ]._strike_and_index_from_atm(
@@ -331,7 +343,7 @@ class FXOption(Sensitivities, Metrics, metaclass=ABCMeta):
                     vol=_validate_obj_not_no_input(vol_, "vol"),  # type: ignore[arg-type]
                     w_deli=w_deli,
                     w_spot=w_spot,
-                    f=self._pricing.f_d,
+                    f=fx_,
                     t_e=self._pricing.t_e,
                 )
 
@@ -349,12 +361,14 @@ class FXOption(Sensitivities, Metrics, metaclass=ABCMeta):
                     t_e=self._pricing.t_e,
                 )
 
-            # Review section in book regarding Hyper-parameters and Solver interaction
-            self.periods[0].strike = self._pricing.k
-            # self._option_periods[0].strike = _dual_float(self._pricing.k)
+        # _PricingMetrics.k is completely specified
+        # Review section in book regarding Hyper-parameters and Solver interaction
+        self.periods[0].strike = self._pricing.k
+        # self._option_periods[0].strike = _dual_float(self._pricing.k)
 
+        # Now determine the volatility knowing the strike on the OptionPeriod
         if isinstance(vol_, FXVolObj):
-            if self._pricing.delta_index is None:
+            if isinstance(vol_, FXSabrSmile):
                 self._pricing.delta_index, self._pricing.vol, _ = vol_.get_from_strike(
                     k=self._pricing.k,
                     f=self._pricing.f_d,
@@ -362,13 +376,33 @@ class FXOption(Sensitivities, Metrics, metaclass=ABCMeta):
                     w_deli=w_deli,
                     w_spot=w_spot,
                 )
-            else:
-                # Sabr objects do not generate delta_index pricing metrics.
-                assert not isinstance(vol_, FXSabrSmile | FXSabrSurface)  # noqa: S101
-                self._pricing.vol = vol_._get_index(
-                    self._pricing.delta_index,
-                    self.kwargs["expiry"],
+            elif isinstance(vol_, FXSabrSurface):
+                self._pricing.delta_index, self._pricing.vol, _ = vol_.get_from_strike(
+                    k=self._pricing.k,
+                    f=fx_,  # SabrSurfaces need an FXForwards object to derive multiple rates.
+                    expiry=self.kwargs["expiry"],
+                    w_deli=w_deli,
+                    w_spot=w_spot,
                 )
+            else:
+                if self._pricing.delta_index is None:
+                    # must use get from strike
+                    self._pricing.vol = vol_.get_from_strike(
+                        k=self._pricing.k,
+                        f=self._pricing.f_d,
+                        expiry=self.kwargs["expiry"],
+                        w_deli=w_deli,
+                        w_spot=w_spot,
+                    )
+                else:
+                    # can call volatility directly from Object with delta_index
+                    self._pricing.vol = vol_._get_index(
+                        self._pricing.delta_index,
+                        self.kwargs["expiry"],
+                    )
+        else:
+            # volatility is a DualType, set directly
+            self._pricing.vol = vol_
 
     def _set_premium(self, curves: Curves_DiscTuple, fx: FX_ = NoInput(0)) -> None:
         if isinstance(self.kwargs["premium"], NoInput):

--- a/python/rateslib/instruments/fx_volatility/vanilla.py
+++ b/python/rateslib/instruments/fx_volatility/vanilla.py
@@ -349,13 +349,9 @@ class FXOption(Sensitivities, Metrics, metaclass=ABCMeta):
                     t_e=self._pricing.t_e,
                 )
 
-            # TODO: this may affect solvers dependent upon sensitivity to vol for changing strikes.
-            # set the strike as a float without any sensitivity. Trade definition is a fixed
-            # quantity at this stage. Similar to setting a fixed rate as a float on an unpriced
-            # IRS for mid-market.
-
-            # self.periods[0].strike = self._pricing["k"]
-            self._option_periods[0].strike = _dual_float(self._pricing.k)
+            # Review section in book regarding Hyper-parameters and Solver interaction
+            self.periods[0].strike = self._pricing.k
+            # self._option_periods[0].strike = _dual_float(self._pricing.k)
 
         if isinstance(vol_, FXVolObj):
             if self._pricing.delta_index is None:
@@ -469,6 +465,9 @@ class FXOption(Sensitivities, Metrics, metaclass=ABCMeta):
             self.kwargs["pair"][3:],
         )
         self._set_strike_and_vol(curves_, fx_, vol_)
+
+        # Premium is not required for rate and also sets as float
+        # Review section: "Hyper-parameters and Solver interaction" before enabling.
         # self._set_premium(curves, fx)
 
         metric = _drb(self.kwargs["metric"], metric)

--- a/python/rateslib/instruments/fx_volatility/vanilla.py
+++ b/python/rateslib/instruments/fx_volatility/vanilla.py
@@ -343,7 +343,7 @@ class FXOption(Sensitivities, Metrics, metaclass=ABCMeta):
                     vol=_validate_obj_not_no_input(vol_, "vol"),  # type: ignore[arg-type]
                     w_deli=w_deli,
                     w_spot=w_spot,
-                    f=fx_,
+                    f=fx_ if isinstance(vol_, FXSabrSurface) else self._pricing.f_d,
                     t_e=self._pricing.t_e,
                 )
 
@@ -357,7 +357,7 @@ class FXOption(Sensitivities, Metrics, metaclass=ABCMeta):
                     vol=_validate_obj_not_no_input(vol_, "vol"),  # type: ignore[arg-type]
                     w_deli=w_deli,
                     w_spot=w_spot,
-                    f=self._pricing.f_d,
+                    f=fx_ if isinstance(vol_, FXSabrSurface) else self._pricing.f_d,
                     t_e=self._pricing.t_e,
                 )
 
@@ -387,7 +387,7 @@ class FXOption(Sensitivities, Metrics, metaclass=ABCMeta):
             else:
                 if self._pricing.delta_index is None:
                     # must use get from strike
-                    self._pricing.vol = vol_.get_from_strike(
+                    self._pricing.delta_index, self._pricing.vol, _ = vol_.get_from_strike(
                         k=self._pricing.k,
                         f=self._pricing.f_d,
                         expiry=self.kwargs["expiry"],

--- a/python/rateslib/instruments/rates/multi_currency.py
+++ b/python/rateslib/instruments/rates/multi_currency.py
@@ -877,7 +877,7 @@ class XCS(BaseDerivative):
                 else:
                     if isinstance(fx, FXForwards):
                         # this is the correct pricing path
-                        fx_fixing = fx.rate(self.pair, self.leg2.periods[0].payment)
+                        fx_fixing = fx.rate(self.pair, self.leg2._exchange_periods[0].payment)  # type: ignore[union-attr]
                     elif isinstance(fx, FXRates):
                         # maybe used in debugging
                         fx_fixing = fx.rate(self.pair)

--- a/python/rateslib/periods/fx_volatility.py
+++ b/python/rateslib/periods/fx_volatility.py
@@ -717,8 +717,18 @@ class FXOptionPeriod(metaclass=ABCMeta):
             return k, None
         else:  # DualTypes | FXDeltaVolSmile | FXDeltaVolSurface
             assert not isinstance(f, FXForwards)  # noqa: S101
+            # TODO mypy errors here: the assertion should narrow the type of f, but does not
             return self._strike_from_atm_dv(
-                f, eta_0, eta_1, z_w_0, z_w_1, vol, t_e, delta_type, vol_delta_type, z_w
+                f,  # type:ignore[arg-type]
+                eta_0,
+                eta_1,
+                z_w_0,
+                z_w_1,
+                vol,
+                t_e,
+                delta_type,
+                vol_delta_type,
+                z_w,
             )
 
     def _strike_from_atm_sabr(
@@ -732,7 +742,8 @@ class FXOptionPeriod(metaclass=ABCMeta):
             f_d: DualTypes = f.rate(self.pair, self.delivery)
             _ad = _set_ad_order_objects([0], [f])
         else:
-            f_d = f
+            # TODO: mypy should narrow the type of f, but it does not
+            f_d = f  # type: ignore[assignment]
 
         def root1d(
             k: DualTypes, f_d: DualTypes, fx: DualTypes | FXForwards, as_float: bool
@@ -819,7 +830,7 @@ class FXOptionPeriod(metaclass=ABCMeta):
         vol: FXVolOption,
         w_deli: DualTypes,
         w_spot: DualTypes,
-        f: DualTypes,
+        f: DualTypes | FXForwards,
         t_e: DualTypes,
     ) -> tuple[DualTypes, DualTypes | None]:
         """
@@ -838,8 +849,9 @@ class FXOptionPeriod(metaclass=ABCMeta):
            The relevant discount factor at delivery.
         w_spot: DualTypes
            The relevant discount factor at spot.
-        f: DualTypes
-           The forward FX rate for delivery.
+        f: DualTypes | FXForwards
+           The forward FX rate for delivery. When using a *SabrSurface* this is required in
+           *FXForwards* form.
         t_e: DualTypes
            The time to expiry
 
@@ -854,7 +866,9 @@ class FXOptionPeriod(metaclass=ABCMeta):
             k = self._strike_from_delta_sabr(delta, delta_type, vol, z_w, f)
             return k, None
         else:  # DualTypes | FXDeltaVolSmile | FXDeltaVolSurface
-            return self._strike_from_delta_dv(f, delta, vol, t_e, delta_type, vol_delta_type, z_w)
+            assert not isinstance(f, FXDeltaVolSurface)  # noqa: S101
+            # TODO: f not type narrowed by assert, mypy error
+            return self._strike_from_delta_dv(f, delta, vol, t_e, delta_type, vol_delta_type, z_w)  # type: ignore[arg-type]
 
     def _strike_from_delta_dv(
         self,
@@ -916,7 +930,8 @@ class FXOptionPeriod(metaclass=ABCMeta):
             f_d: DualTypes = f.rate(self.pair, self.delivery)
             _ad = _set_ad_order_objects([0], [f])
         else:
-            f_d = f
+            # TODO: mypy should narrow type of f, but does not
+            f_d = f  # type: ignore[assignment]
 
         def root1d(
             k: DualTypes,

--- a/python/rateslib/periods/fx_volatility.py
+++ b/python/rateslib/periods/fx_volatility.py
@@ -716,7 +716,7 @@ class FXOptionPeriod(metaclass=ABCMeta):
             k = self._strike_from_atm_sabr(f, eta_0, vol)
             return k, None
         else:  # DualTypes | FXDeltaVolSmile | FXDeltaVolSurface
-            assert not isinstance(f, FXForwards)  # should not pass when only 1 rate required.
+            assert not isinstance(f, FXForwards)  # noqa: S101
             return self._strike_from_atm_dv(
                 f, eta_0, eta_1, z_w_0, z_w_1, vol, t_e, delta_type, vol_delta_type, z_w
             )
@@ -734,7 +734,9 @@ class FXOptionPeriod(metaclass=ABCMeta):
         else:
             f_d = f
 
-        def root1d(k: DualTypes, f_d: DualTypes, fx: DualTypes | FXForwards, as_float: bool) -> tuple[DualTypes, DualTypes]:
+        def root1d(
+            k: DualTypes, f_d: DualTypes, fx: DualTypes | FXForwards, as_float: bool
+        ) -> tuple[DualTypes, DualTypes]:
             if not as_float and isinstance(fx, FXForwards):
                 _set_ad_order_objects(_ad, [fx])
             sigma, dsigma_dk = vol._d_sabr_d_k(k, fx, self.expiry, as_float)
@@ -917,7 +919,12 @@ class FXOptionPeriod(metaclass=ABCMeta):
             f_d = f
 
         def root1d(
-            k: DualTypes, f_d: DualTypes, fx: FXForwards | DualTypes, z_w_0: DualTypes, delta: float, as_float: bool
+            k: DualTypes,
+            f_d: DualTypes,
+            fx: FXForwards | DualTypes,
+            z_w_0: DualTypes,
+            delta: float,
+            as_float: bool,
         ) -> tuple[DualTypes, DualTypes]:
             if not as_float and isinstance(fx, FXForwards):
                 _set_ad_order_objects(_ad, [fx])

--- a/python/tests/test_instruments.py
+++ b/python/tests/test_instruments.py
@@ -5491,12 +5491,11 @@ class TestFXOptions:
         surf = FXSabrSurface(
             eval_date=dt(2023, 3, 16),
             expiries=[dt(2023, 6, 16), dt(2023, 10, 17)],
-            node_values=[
-                [0.05, 1.0, 0.03, 0.04],
-                [0.055, 1.0, 0.04, 0.05]
-            ],
+            node_values=[[0.05, 1.0, 0.03, 0.04], [0.055, 1.0, 0.04, 0.05]],
             pair="eurusd",
             calendar="tgt|fed",
+            ad=1,
+            id="v",
         )
         fxc = FXCall(
             expiry=dt(2023, 7, 21),
@@ -5505,9 +5504,14 @@ class TestFXOptions:
             delta_type="spot",
             curves=[None, fxfo.curve("eur", "usd"), None, fxfo.curve("usd", "usd")],
             vol=surf,
-            strike=k
+            strike=k,
         )
-        result = fxc.rate(fx=fxfo)
+        fxc.rate(fx=fxfo)
+        result = fxc._pricing
+        assert abs(result.vol - 5.25) < 1e-2
+        assert np.all(gradient(result.vol, vars=["v_0_0", "v_1_0"]) > 49.2)
+        assert np.all(gradient(result.vol, vars=["v_0_0", "v_1_0"]) < 50.6)
+
 
 
 

--- a/python/tests/test_instruments.py
+++ b/python/tests/test_instruments.py
@@ -5362,6 +5362,101 @@ class TestFXOptions:
         with pytest.raises(ValueError, match="`vol` must be supplied. Got"):
             fxo.rate(metric="vol", fx=fxfo)
 
+    def test_hyper_parameter_setting_and_solver_interaction(self):
+        # Define the interest rate curves for EUR, USD and X-Ccy basis
+        usdusd = Curve({dt(2024, 5, 7): 1.0, dt(2024, 5, 30): 1.0}, calendar="nyc", id="usdusd")
+        eureur = Curve({dt(2024, 5, 7): 1.0, dt(2024, 5, 30): 1.0}, calendar="tgt", id="eureur")
+        eurusd = Curve({dt(2024, 5, 7): 1.0, dt(2024, 5, 30): 1.0}, id="eurusd")
+
+        # Create an FX Forward market with spot FX rate data
+        fxr = FXRates({"eurusd": 1.0760}, settlement=dt(2024, 5, 9))
+        fxf = FXForwards(
+            fx_rates=fxr,
+            fx_curves={"eureur": eureur, "usdusd": usdusd, "eurusd": eurusd},
+        )
+
+        pre_solver = Solver(
+            curves=[eureur, eurusd, usdusd],
+            instruments=[
+                IRS(dt(2024, 5, 9), "3W", spec="eur_irs", curves="eureur"),
+                IRS(dt(2024, 5, 9), "3W", spec="usd_irs", curves="usdusd"),
+                FXSwap(
+                    dt(2024, 5, 9), "3W", pair="eurusd", curves=[None, "eurusd", None, "usdusd"]
+                ),
+            ],
+            s=[3.90, 5.32, 8.85],
+            fx=fxf,
+            id="rates_sv",
+        )
+        dv_smile = FXDeltaVolSmile(
+            nodes={
+                0.10: 10.0,
+                0.25: 10.0,
+                0.50: 10.0,
+                0.75: 10.0,
+                0.90: 10.0,
+            },
+            eval_date=dt(2024, 5, 7),
+            expiry=dt(2024, 5, 28),
+            delta_type="spot",
+            id="eurusd_3w_smile",
+        )
+        option_args = dict(
+            pair="eurusd",
+            expiry=dt(2024, 5, 28),
+            calendar="tgt|fed",
+            delta_type="spot",
+            curves=[None, "eurusd", None, "usdusd"],
+            vol="eurusd_3w_smile",
+        )
+
+        dv_solver = Solver(
+            pre_solvers=[pre_solver],
+            curves=[dv_smile],
+            instruments=[
+                FXStraddle(strike="atm_delta", **option_args),
+                FXRiskReversal(strike=("-25d", "25d"), **option_args),
+                FXRiskReversal(strike=("-10d", "10d"), **option_args),
+                FXBrokerFly(strike=(("-25d", "25d"), "atm_delta"), **option_args),
+                FXBrokerFly(strike=(("-10d", "10d"), "atm_delta"), **option_args),
+            ],
+            s=[5.493, -0.157, -0.289, 0.071, 0.238],
+            fx=fxf,
+            id="dv_solver",
+        )
+        fc = FXCall(
+            expiry=dt(2024, 5, 28),
+            pair="eurusd",
+            strike=1.07,
+            notional=100e6,
+            curves=[None, "eurusd", None, "usdusd"],
+            vol="eurusd_3w_smile",
+            premium=98.216647 * 1e8 / 1e4,
+            premium_ccy="usd",
+            delta_type="spot",
+        )
+        assert abs(fc.npv(solver=dv_solver, base="usd")) < 1e-2
+        delta = fc.delta(solver=dv_solver, base="usd").loc[("fx", "fx", "eurusd"), ("all", "usd")]
+        gamma = fc.gamma(solver=dv_solver, base="usd").loc[
+            ("all", "usd", "fx", "fx", "eurusd"), ("fx", "fx", "eurusd")
+        ]
+
+        fxr.update({"eurusd": 1.0761})
+        pre_solver.iterate()
+        dv_solver.iterate()
+
+        result = fc.npv(solver=dv_solver, base="usd")
+        expected = delta + 0.5 * gamma
+        assert abs(result - expected) < 5e-2
+
+        fxr.update({"eurusd": 1.0759})
+        pre_solver.iterate()
+        dv_solver.iterate()
+
+        result = fc.npv(solver=dv_solver, base="usd")
+        expected = -delta + 0.5 * gamma
+        assert abs(result - expected) < 5e-2
+
 
 class TestRiskReversal:
     @pytest.mark.parametrize(

--- a/python/tests/test_instruments.py
+++ b/python/tests/test_instruments.py
@@ -5513,8 +5513,6 @@ class TestFXOptions:
         assert np.all(gradient(result.vol, vars=["v_0_0", "v_1_0"]) < 50.6)
 
 
-
-
 class TestRiskReversal:
     @pytest.mark.parametrize(
         ("metric", "expected"),


### PR DESCRIPTION
Handle SabrSurface solves which require an FXForwards object to forecast multiple relevant rates. Previously only a single forward rate was required for all other calculations to date.