### PR TITLE
REF: convert all `Leg` arguments to a `Schedule` (#86)

### DIFF
--- a/python/rateslib/instruments/base.py
+++ b/python/rateslib/instruments/base.py
@@ -11,6 +11,7 @@ from rateslib import defaults
 from rateslib.default import NoInput
 from rateslib.instruments.sensitivities import Sensitivities
 from rateslib.instruments.utils import (
+    _convert_to_schedule_kwargs,
     _get_curves_fx_and_base_maybe_from_solver,
     _inherit_or_negate,
     _push,
@@ -588,6 +589,9 @@ class BaseDerivative(Sensitivities, Metrics, metaclass=ABCMeta):
         if self.kwargs["payment_lag"] is NoInput.blank:
             self.kwargs["payment_lag"] = defaults.payment_lag_specific[type(self).__name__]
         self.kwargs = _inherit_or_negate(self.kwargs)  # inherit or negate the complete arg list
+
+        self.kwargs = _convert_to_schedule_kwargs(self.kwargs, leg=1)
+        self.kwargs = _convert_to_schedule_kwargs(self.kwargs, leg=2)
 
         self.curves = curves
         self.spec = spec

--- a/python/rateslib/instruments/credit/derivatives.py
+++ b/python/rateslib/instruments/credit/derivatives.py
@@ -50,13 +50,15 @@ class CDS(BaseDerivative):
         premium_accrued: bool | NoInput = NoInput(0),
         **kwargs: Any,
     ) -> None:
+        # pre-scheduling overloads
+        kwargs["leg2_frequency"] = "Z"  # CDS protection is only ever one payoff
         super().__init__(*args, **kwargs)
+
         cds_specific: dict[str, Any] = dict(
             initial_exchange=False,  # CDS have no exchanges
             final_exchange=False,
             leg2_initial_exchange=False,
             leg2_final_exchange=False,
-            leg2_frequency="Z",  # CDS protection is only ever one payoff
             fixed_rate=fixed_rate,
             premium_accrued=premium_accrued,
         )

--- a/python/rateslib/instruments/utils.py
+++ b/python/rateslib/instruments/utils.py
@@ -11,6 +11,7 @@ from rateslib.default import NoInput
 from rateslib.dual import Dual, Dual2, Variable
 from rateslib.fx import FXForwards, FXRates
 from rateslib.fx_volatility import FXSabrSmile, FXSabrSurface
+from rateslib.scheduling import Schedule
 
 if TYPE_CHECKING:
     from rateslib.typing import (
@@ -246,6 +247,24 @@ def _push(spec: str_, kwargs: dict[str, Any]) -> dict[str, Any]:
 
         user = {k: v for k, v in kwargs.items() if not isinstance(v, NoInput)}
         return {**kwargs, **spec_kwargs, **user}
+
+
+def _convert_to_schedule_kwargs(kwargs: dict[str, Any], leg: int) -> dict[str, Any]:
+    _ = "" if leg == 1 else "leg2_"
+    kwargs[f"{_}schedule"] = Schedule(
+        effective=kwargs.pop(f"{_}effective"),
+        termination=kwargs.pop(f"{_}termination"),
+        frequency=kwargs.pop(f"{_}frequency"),
+        stub=kwargs.pop(f"{_}stub"),
+        front_stub=kwargs.pop(f"{_}front_stub"),
+        back_stub=kwargs.pop(f"{_}back_stub"),
+        roll=kwargs.pop(f"{_}roll"),
+        eom=kwargs.pop(f"{_}eom"),
+        modifier=kwargs.pop(f"{_}modifier"),
+        calendar=kwargs.pop(f"{_}calendar"),
+        payment_lag=kwargs.pop(f"{_}payment_lag"),
+    )
+    return kwargs
 
 
 def _update_not_noinput(base_kwargs: dict[str, Any], new_kwargs: dict[str, Any]) -> dict[str, Any]:

--- a/python/rateslib/legs/base.py
+++ b/python/rateslib/legs/base.py
@@ -24,16 +24,13 @@ if TYPE_CHECKING:
         FX_,
         NPV,
         Any,
-        CalInput,
         CurveOption_,
         DualTypes,
         DualTypes_,
         FixingsRates_,
         Period,
         _BaseCurve,
-        bool_,
         datetime,
-        datetime_,
         int_,
         str_,
     )
@@ -49,34 +46,8 @@ class BaseLeg(metaclass=ABCMeta):
 
     Parameters
     ----------
-    effective : datetime
-        The adjusted or unadjusted effective date.
-    termination : datetime or str
-        The adjusted or unadjusted termination date. If a string, then a tenor must be
-        given expressed in days (`"D"`), months (`"M"`) or years (`"Y"`), e.g. `"48M"`.
-    frequency : str in {"M", "B", "Q", "T", "S", "A", "Z"}, optional
-        The frequency of the schedule.
-    stub : str combining {"SHORT", "LONG"} with {"FRONT", "BACK"}, optional
-        The stub type to enact on the swap. Can provide two types, for
-        example "SHORTFRONTLONGBACK".
-    front_stub : datetime, optional
-        An adjusted or unadjusted date for the first stub period.
-    back_stub : datetime, optional
-        An adjusted or unadjusted date for the back stub period.
-        See notes for combining ``stub``, ``front_stub`` and ``back_stub``
-        and any automatic stub inference.
-    roll : int in [1, 31] or str in {"eom", "imm", "som"}, optional
-        The roll day of the schedule. Inferred if not given.
-    eom : bool, optional
-        Use an end of month preference rather than regular rolls for inference. Set by
-        default. Not required if ``roll`` is specified.
-    modifier : str, optional
-        The modification rule, in {"F", "MF", "P", "MP"}
-    calendar : calendar or str, optional
-        The holiday calendar object to use. If str, looks up named calendar from
-        static data. See :meth:`~rateslib.scheduling.get_calendar`.
-    payment_lag : int, optional
-        The number of business days to lag payments by on regular accrual periods.
+    schedule: Schedule
+        The :class:`~rateslib.scheduling.Schedule` object which structures contiguous *Periods*.
     notional : float, optional
         The leg notional, which is applied to each period.
     currency : str, optional
@@ -98,9 +69,6 @@ class BaseLeg(metaclass=ABCMeta):
 
     Notes
     -----
-    See also :class:`~rateslib.scheduling.Schedule` for a more thorough description
-    of some of these scheduling arguments.
-
     The (optional) initial cashflow notional is set as the negative of the notional.
     The payment date is set equal to the accrual start date adjusted by
     the ``payment_lag_exchange``.
@@ -142,18 +110,8 @@ class BaseLeg(metaclass=ABCMeta):
     @abstractmethod
     def __init__(
         self,
-        effective: datetime,
-        termination: datetime | str,
-        frequency: str,
+        schedule: Schedule,
         *,
-        stub: str_ = NoInput(0),
-        front_stub: datetime_ = NoInput(0),
-        back_stub: datetime_ = NoInput(0),
-        roll: int | str_ = NoInput(0),
-        eom: bool_ = NoInput(0),
-        modifier: str_ = NoInput(0),
-        calendar: CalInput = NoInput(0),
-        payment_lag: int_ = NoInput(0),
         notional: DualTypes_ = NoInput(0),
         currency: str_ = NoInput(0),
         amortization: DualTypes_ = NoInput(0),
@@ -162,19 +120,7 @@ class BaseLeg(metaclass=ABCMeta):
         initial_exchange: bool = False,
         final_exchange: bool = False,
     ) -> None:
-        self.schedule = Schedule(
-            effective=effective,
-            termination=termination,
-            frequency=frequency,
-            stub=stub,
-            front_stub=front_stub,
-            back_stub=back_stub,
-            roll=roll,
-            eom=eom,
-            modifier=modifier,
-            calendar=calendar,
-            payment_lag=payment_lag,
-        )
+        self.schedule = schedule
         self.convention: str = _drb(defaults.convention, convention)
         self.currency: str = _drb(defaults.base_currency, currency).lower()
         self.payment_lag_exchange: int = _drb(defaults.payment_lag_exchange, payment_lag_exchange)

--- a/python/rateslib/legs/credit.py
+++ b/python/rateslib/legs/credit.py
@@ -52,6 +52,7 @@ class CreditPremiumLeg(_FixedLegMixin, BaseLeg):
        :suppress:
 
        from rateslib.curves import Curve
+       from rateslib.scheduling import Schedule
        from rateslib.legs import CreditPremiumLeg
        from datetime import datetime as dt
 
@@ -60,7 +61,7 @@ class CreditPremiumLeg(_FixedLegMixin, BaseLeg):
        disc_curve = Curve({dt(2022, 1, 1): 1.0, dt(2023, 1, 1): 0.98})
        hazard_curve = Curve({dt(2022, 1, 1): 1.0, dt(2023, 1, 1): 0.995})
        premium_leg = CreditPremiumLeg(
-           dt(2022, 1, 1), "9M", "Q",
+           schedule=Schedule(dt(2022, 1, 1), "9M", "Q"),
            fixed_rate=2.60,
            notional=1000000,
        )
@@ -198,6 +199,7 @@ class CreditProtectionLeg(BaseLeg):
        :suppress:
 
        from rateslib.curves import Curve
+       from rateslib.scheduling import Schedule
        from rateslib.legs import CreditProtectionLeg
        from datetime import datetime as dt
 
@@ -206,7 +208,7 @@ class CreditProtectionLeg(BaseLeg):
        disc_curve = Curve({dt(2022, 1, 1): 1.0, dt(2023, 1, 1): 0.98})
        hazard_curve = Curve({dt(2022, 1, 1): 1.0, dt(2023, 1, 1): 0.995})
        protection_leg = CreditProtectionLeg(
-           dt(2022, 1, 1), "9M", "Z",
+           schedule=Schedule(dt(2022, 1, 1), "9M", "Z"),
            notional=1000000,
        )
        protection_leg.cashflows(hazard_curve, disc_curve)

--- a/python/rateslib/legs/index.py
+++ b/python/rateslib/legs/index.py
@@ -147,14 +147,13 @@ class ZeroIndexLeg(_IndexLegMixin, BaseLeg):
        :suppress:
 
        from rateslib import ZeroIndexLeg
+       from rateslib.scheduling import Schedule
 
     .. ipython:: python
 
        index_curve = Curve({dt(2022, 1, 1): 1.0, dt(2027, 1, 1): 0.95}, index_base=100.0)
        zil = ZeroIndexLeg(
-           effective=dt(2022, 1, 15),
-           termination="3Y",
-           frequency="S",
+           schedule=Schedule(dt(2022, 1, 15), "3Y", "S"),
            index_method="monthly",
            index_base=100.25,
        )
@@ -326,13 +325,14 @@ class IndexFixedLeg(_IndexLegMixin, _FixedLegMixin, BaseLeg):  # type: ignore[mi
        :suppress:
 
        from rateslib import IndexFixedLeg
+       from rateslib.scheduling import Schedule
 
     .. ipython:: python
 
        curve = Curve({dt(2022, 1, 1): 1.0, dt(2023, 1, 1): 0.98})
        index_curve = Curve({dt(2022, 1, 1): 1.0, dt(2023, 1, 1): 0.99}, index_base=100.0)
        index_leg_exch = IndexFixedLeg(
-           dt(2022, 1, 1), "9M", "Q",
+           schedule=Schedule(dt(2022, 1, 1), "9M", "Q"),
            notional=1000000,
            amortization=200000,
            index_base=100.0,

--- a/python/rateslib/legs/rates.py
+++ b/python/rateslib/legs/rates.py
@@ -60,12 +60,13 @@ class FixedLeg(_FixedLegMixin, BaseLeg):  # type: ignore[misc]
        :suppress:
 
        from rateslib import FixedLeg
+       from rateslib.scheduling import Schedule
 
     .. ipython:: python
 
        curve = Curve({dt(2022, 1, 1): 1.0, dt(2023, 1, 1): 0.98})
        fixed_leg_exch = FixedLeg(
-           dt(2022, 1, 1), "9M", "Q",
+           schedule=Schedule(dt(2022, 1, 1), "9M", "Q"),
            fixed_rate=2.0,
            notional=1000000,
            amortization=200000,
@@ -181,13 +182,12 @@ class FloatLeg(_FloatLegMixin, BaseLeg):
        :suppress:
 
        from rateslib import FloatLeg
+       from rateslib.scheduling import Schedule
 
     .. ipython:: python
 
        float_leg = FloatLeg(
-           effective=dt(2021, 12, 1),
-           termination="9M",
-           frequency="Q",
+           schedule=Schedule(dt(2021, 12, 1), "9M", "Q"),
            fixing_method="ibor",
            fixings=2.00,
        )
@@ -198,9 +198,7 @@ class FloatLeg(_FloatLegMixin, BaseLeg):
     .. ipython:: python
 
        float_leg = FloatLeg(
-           effective=dt(2021, 9, 1),
-           termination="12M",
-           frequency="Q",
+           schedule=Schedule(dt(2021, 9, 1), "12M", "Q"),
            fixing_method="ibor",
            fixings=[1.00, 2.00],
        )
@@ -212,9 +210,7 @@ class FloatLeg(_FloatLegMixin, BaseLeg):
     .. ipython:: python
 
        float_leg = FloatLeg(
-           effective=dt(2021, 9, 1),
-           termination="12M",
-           frequency="Q",
+           schedule=Schedule(dt(2021, 9, 1), "12M", "Q"),
            fixing_method="ibor",
            method_param=0,
            fixings=Series([1.00, 2.00], index=[dt(2021, 9, 1), dt(2021, 12, 1)])
@@ -228,12 +224,9 @@ class FloatLeg(_FloatLegMixin, BaseLeg):
 
        swestr_curve = Curve({dt(2023, 1, 2): 1.0, dt(2023, 7, 2): 0.99}, calendar="stk")
        float_leg = FloatLeg(
-           effective=dt(2022, 12, 28),
-           termination="2M",
-           frequency="M",
+           schedule=Schedule(dt(2022, 12, 28), "2M", "M", calendar="stk"),
            fixings=[[1.19, 1.19, -8.81]],
            currency="SEK",
-           calendar="stk"
        )
        float_leg.cashflows(swestr_curve)
        float_leg.fixings_table(swestr_curve)[dt(2022,12,28):dt(2023,1,4)]
@@ -244,12 +237,9 @@ class FloatLeg(_FloatLegMixin, BaseLeg):
     .. ipython:: python
 
        float_leg = FloatLeg(
-           effective=dt(2022, 12, 28),
-           termination="2M",
-           frequency="M",
+           schedule=Schedule(dt(2022, 12, 28), "2M", "M", calendar="stk"),
            fixings=Series([1.19, 1.19, -8.81], index=[dt(2022, 12, 28), dt(2022, 12, 29), dt(2022, 12, 30)]),
            currency="SEK",
-           calendar="stk",
        )
        float_leg.cashflows(swestr_curve)
        float_leg.fixings_table(swestr_curve)[dt(2022,12,28):dt(2023,1,4)]

--- a/python/rateslib/legs/zeros.py
+++ b/python/rateslib/legs/zeros.py
@@ -89,13 +89,12 @@ class ZeroFloatLeg(_FloatLegMixin, BaseLeg):
        :suppress:
 
        from rateslib import ZeroFloatLeg
+       from rateslib.scheduling import Schedule
 
     .. ipython:: python
 
        zfl = ZeroFloatLeg(
-           effective=dt(2022, 1, 1),
-           termination="3Y",
-           frequency="S",
+           schedule=Schedule(dt(2022, 1, 1), "3Y", "S"),
            fixing_method="ibor",
            method_param=0,
            float_spread=100.0
@@ -399,13 +398,12 @@ class ZeroFixedLeg(_FixedLegMixin, BaseLeg):  # type: ignore[misc]
        :suppress:
 
        from rateslib import ZeroFixedLeg
+       from rateslib.scheduling import Schedule
 
     .. ipython:: python
 
        zfl = ZeroFixedLeg(
-           effective=dt(2022, 1, 1),
-           termination="3Y",
-           frequency="S",
+           schedule=Schedule(dt(2022, 1, 1), "3Y", "S"),
            convention="1+",
            fixed_rate=5.0
        )


### PR DESCRIPTION
Co-authored-by: JHM Darbyshire (M1) <attack68@users.noreply.github.com>

(cherry picked from commit 0ad014425dd906fcb5d36a0a1b6f40b3d937fbfb)