### PR TITLE
REF: `get_calendar` replaces whitespace (#228)

### DIFF
--- a/python/rateslib/data/fixings.py
+++ b/python/rateslib/data/fixings.py
@@ -568,7 +568,10 @@ def _fx_index_set_cross(pair: FXIndex, allow_cross: bool) -> FXIndex:
 
 
 class _UnitFixing(_BaseFixing):
-    """A :class:`~rateslib.data.fixings._BaseFixing` permanently adopting value 1.0. Used as a placeholder."""
+    """
+    A :class:`~rateslib.data.fixings._BaseFixing` permanently adopting value 1.0.
+    Used as a placeholder.
+    """
 
     def __init__(
         self, *, date: datetime, value: DualTypes_ = NoInput(0), identifier: str_ = NoInput(0)
@@ -767,7 +770,7 @@ class FXFixing(_BaseFixing):
        fxfix.value_or_forecast(fx=fxf)
        fxf.rate("cadsek", dt(2026, 1, 8))
 
-    """
+    """  # noqa: E501
 
     def __init__(
         self,

--- a/python/rateslib/scheduling/calendars.py
+++ b/python/rateslib/scheduling/calendars.py
@@ -91,6 +91,7 @@ def get_calendar(
     """
     if isinstance(calendar, str):
         # parse the string in Python and return Rust Cal/UnionCal objects directly
+        calendar = calendar.replace(" ", "")
         if calendar in defaults.calendars:
             return defaults.calendars[calendar]
         return _parse_str_calendar(calendar, named)

--- a/python/tests/scheduling/test_calendars.py
+++ b/python/tests/scheduling/test_calendars.py
@@ -705,3 +705,9 @@ def test_mex_loads():
     cal = get_calendar("mex")
     assert not cal.is_bus_day(dt(2026, 3, 16))
     assert cal.is_bus_day(dt(2026, 3, 17))
+
+
+def test_replace_whitespace():
+    cal1 = get_calendar("nyc, tgt")
+    cal2 = get_calendar("nyc,tgt")
+    assert cal1 == cal2


### PR DESCRIPTION
(cherry picked from commit 573bff2cd7c15034ed3e7f1283ddf089d234c4d6)