### PR TITLE
BUG: `ZeroFixedLeg.spread` now factors `final_exchange` into the calc…

### DIFF
--- a/rust/scheduling/frequency/imm.rs
+++ b/rust/scheduling/frequency/imm.rs
@@ -146,7 +146,7 @@ impl Imm {
                 let date = NaiveDate::from_ymd_opt(year, month, 1);
                 match date {
                     Some(d) => Ok(d.and_hms_opt(0, 0, 0).unwrap()),
-                    None => {return Err(PyValueError::new_err("`year` or `month` out of range."))}
+                    None => return Err(PyValueError::new_err("`year` or `month` out of range.")),
                 }
             }
             Imm::Leap => {


### PR DESCRIPTION
…… (#248)

Co-authored-by: JHM Darbyshire (M1) <attack68@users.noreply.github.com>

(cherry picked from commit ce720ff7b798789c6a4379243475c14a2f7b0eb1)