### PR TITLE
BUG: `de_gb` change to 'linear_days_long front split' (#249)

### DIFF
--- a/python/rateslib/instruments/bonds/conventions/__init__.py
+++ b/python/rateslib/instruments/bonds/conventions/__init__.py
@@ -597,8 +597,8 @@ CA_GB = BondCalcMode(
 
 DE_GB = BondCalcMode(
     # German government bonds
-    settle_accrual="linear_days",
-    ytm_accrual="linear_days",
+    settle_accrual="linear_days_long_front_split",
+    ytm_accrual="linear_days_long_front_split",
     v1="compounding_final_simple",
     v2="regular",
     v3="compounding",


### PR DESCRIPTION
Co-authored-by: JHM Darbyshire (M1) <attack68@users.noreply.github.com>
Co-authored-by: Mike Lync <mikelync@users.noreply.github.com>

(cherry picked from commit c0ac373590bf859e379ea379a83df984dcfd0750)