### PR TITLE
ENH: allow `FloatLeg` to be sub-composed with `ZeroFloatPeriod` (#252)

### DIFF
--- a/python/rateslib/default.py
+++ b/python/rateslib/default.py
@@ -22,7 +22,7 @@ import numpy as np
 from rateslib._spec_loader import INSTRUMENT_SPECS
 from rateslib.enums.generics import NoInput, _drb
 from rateslib.enums.parameters import FloatFixingMethod
-from rateslib.rs import Adjuster, Convention, NamedCal
+from rateslib.rs import Adjuster, Convention, NamedCal, StubInference
 
 PlotOutput = tuple[plt.Figure, plt.Axes, list[plt.Line2D]]  # type: ignore[name-defined]
 

--- a/python/rateslib/enums/parameters.py
+++ b/python/rateslib/enums/parameters.py
@@ -53,7 +53,7 @@ _LEG_MTM_MAP = {
 }
 
 
-def _get_let_mtm(leg_mtm: str | LegMtm) -> LegMtm:
+def _get_leg_mtm(leg_mtm: str | LegMtm) -> LegMtm:
     if isinstance(leg_mtm, LegMtm):
         return leg_mtm
     else:

--- a/python/rateslib/legs/fixed.py
+++ b/python/rateslib/legs/fixed.py
@@ -21,7 +21,7 @@ from rateslib.curves._parsers import (
 )
 from rateslib.data.fixings import _leg_fixings_to_list
 from rateslib.enums.generics import NoInput, _drb
-from rateslib.enums.parameters import LegMtm, _get_let_mtm
+from rateslib.enums.parameters import LegMtm, _get_leg_mtm
 from rateslib.legs.amortization import Amortization, _AmortizationType, _get_amortization
 from rateslib.legs.protocols import (
     _BaseLeg,
@@ -594,7 +594,7 @@ class FixedLeg(_BaseLeg, _WithExDiv):
         del currency
         self._convention: str = _drb(defaults.convention, convention)
         del convention
-        self._mtm = _get_let_mtm(mtm)
+        self._mtm = _get_leg_mtm(mtm)
         del mtm
 
         index_fixings_ = _leg_fixings_to_list(index_fixings, self.schedule.n_periods)

--- a/python/rateslib/scheduling/frequency.py
+++ b/python/rateslib/scheduling/frequency.py
@@ -100,7 +100,7 @@ def _get_tenor_from_frequency(frequency: Frequency) -> str:
         return f"{frequency.number}M"
     elif isinstance(frequency, Frequency.CalDays):
         if frequency.number % 7 == 0:
-            return f"{frequency.number / 7}W"
+            return f"{int(frequency.number / 7)}W"
         else:
             return f"{frequency.number}D"
     elif isinstance(frequency, Frequency.BusDays):

--- a/python/rateslib/typing.py
+++ b/python/rateslib/typing.py
@@ -102,6 +102,7 @@ from rateslib.periods.parameters import _PeriodParams as _PeriodParams
 from rateslib.periods.parameters import _SettlementParams as _SettlementParams
 from rateslib.periods.protocols import _BasePeriod as _BasePeriod
 from rateslib.rs import Adjuster as Adjuster
+from rateslib.rs import StubInference as StubInference
 from rateslib.rs import (
     Cal,
     FlatBackwardInterpolator,


### PR DESCRIPTION
Co-authored-by: Mike Lync <mikelync@users.noreply.github.com>

(cherry picked from commit 9459f74527c80e299393701e3dc26485b786f8ab)