### PR TITLE
RLS: upgrade names to 2.7.0 (#320)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rateslib"
-version = "2.6.1"
+version = "2.7.0"
 edition = "2021"
 exclude = [
     ".github/*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ features = ["pyo3/extension-module"]
 
 [project]
 name = "rateslib"
-version = "2.6.1"
+version = "2.7.0"
 description = "A fixed income library for trading interest rates"
 readme = "README.md"
 authors = [{ name = "J H M Darbyshire"}]

--- a/python/rateslib/verify.py
+++ b/python/rateslib/verify.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
         Any,
     )
 
-VERSION = "2.6.1"
+VERSION = "2.7.0"
 
 
 class LicenceNotice(UserWarning):

--- a/python/tests/test_default.py
+++ b/python/tests/test_default.py
@@ -26,7 +26,7 @@ from rateslib.verify import LicenceNotice, _LicenceStatus
 
 
 def test_version() -> None:
-    assert __version__ == "2.6.1"
+    assert __version__ == "2.7.0"
 
 
 def test_context_raises() -> None:


### PR DESCRIPTION
(cherry picked from commit 46bbbf8cfdcbbafb0e30c27d7a6b4b07113ef828)