### PR TITLE
FIX: numpy renamed parameter for lower versions (#323)

### DIFF
--- a/python/rateslib/volatility/ir/sabr.py
+++ b/python/rateslib/volatility/ir/sabr.py
@@ -650,7 +650,7 @@ class IRSabrCube(_WithState, _WithCache[tuple[datetime, datetime], IRSabrSmile])
                         )
                         for j in range(n)
                     ],
-                    shape=(en, tn),
+                    (en, tn),
                 )
 
     def _get_node_vector(self) -> np.ndarray[tuple[int, ...], np.dtype[np.object_]]:

--- a/python/tests/test_ir_volatility.py
+++ b/python/tests/test_ir_volatility.py
@@ -48,7 +48,7 @@ def test_bilinear_interp(h, v, expected):
 
 def test_numpy_ravel_for_dates_posix():
     a = np.array([[1, 1, 2], [3, 4, 5]])
-    b = np.reshape(list(a.ravel()), shape=(2, 3))
+    b = np.reshape(list(a.ravel()), (2, 3))
     assert np.all(a == b)
 
 


### PR DESCRIPTION
(cherry picked from commit b8827c6660d3bcaf9dc290c5a85683b685c5980a)