### PR TITLE
ENH: `FloatLeg` with zero_periods allows `PeriodOnPeriod` index base …

### DIFF
--- a/python/rateslib/legs/float.py
+++ b/python/rateslib/legs/float.py
@@ -668,11 +668,6 @@ class FloatLeg(_BaseLeg, _WithExDiv):
                     "Therefore more parameters are required to properly specify the scheduling.\n"
                     "See Notes."
                 )
-            if index_base_type_ is LegIndexBase.PeriodOnPeriod:
-                raise ValueError(
-                    "Cannot use `PeriodOnPeriod` LegIndexBase type with a a FloatLeg with "
-                    "`zero_periods` as True."
-                )
             fixing_series_ = _init_float_rate_series(
                 fixing_series=fixing_series,
                 calendar=self._schedule.calendar,
@@ -727,7 +722,9 @@ class FloatLeg(_BaseLeg, _WithExDiv):
                         index_lag=index_lag,
                         index_method=index_method,
                         index_fixings=index_fixings_[i],
-                        index_base_date=self.schedule.aschedule[0],  # PeriodOnPeriod ValueErr above
+                        index_base_date=self.schedule.aschedule[0]
+                        if index_base_type_ is LegIndexBase.Initial
+                        else self.schedule.aschedule[i],
                         index_reference_date=self._schedule.aschedule[i + 1],
                         index_only=index_only,
                         # meta

--- a/python/tests/legs/test_legs_legacy.py
+++ b/python/tests/legs/test_legs_legacy.py
@@ -1203,6 +1203,22 @@ class TestFloatLeg:
         for i in range(4):
             assert abs(result.loc[i, "Cashflow"] - expected[i]) < 1e-2
 
+    def test_period_on_period_zero_periods(self):
+        fl = FloatLeg(
+            schedule=Schedule(
+                effective=dt(2000, 1, 7),
+                termination=dt(2000, 3, 7),
+                frequency="M",
+                calendar="all",
+            ),
+            zero_periods=True,
+            fixing_frequency="7d",
+            index_base_type=LegIndexBase.PeriodOnPeriod,
+            index_lag=2,
+        )
+        assert fl.periods[0].index_params.index_base.date == dt(2000, 1, 7)
+        assert fl.periods[1].index_params.index_base.date == dt(2000, 2, 7)
+
 
 class TestZeroFloatLeg:
     def test_zero_float_leg_set_float_spread(self, curve) -> None:


### PR DESCRIPTION
…(#365)

(cherry picked from commit 35be07d4a62acf77825c58f4ca301dc7745b214c)