### PR TITLE
REF: `ActAct` is no longer a valid convention (#368)

### DIFF
--- a/python/rateslib/scheduling/convention.py
+++ b/python/rateslib/scheduling/convention.py
@@ -47,7 +47,6 @@ _CONVENTIONS_MAP: dict[str, Convention] = {
     "1": Convention.One,
     "ONE": Convention.One,
     ###
-    "ACTACT": Convention.ActActISDA,
     "ACTACTISDA": Convention.ActActISDA,
     "ACTACTICMA": Convention.ActActICMA,
     "ACTACTISMA": Convention.ActActICMA,
@@ -68,6 +67,11 @@ def _get_convention(convention: Convention | str) -> Convention:
         try:
             return _CONVENTIONS_MAP[convention.upper()]
         except KeyError:
+            if convention.upper() == "ACTACT":
+                raise ValueError(
+                    "`ActAct` must be directly specified as `ActActICMA` (most common for bonds) "
+                    "or `ActActISDA` (rarely used)."
+                )
             raise ValueError(f"`convention`: {convention}, is not valid.")
 
 

--- a/python/tests/legs/test_legs_legacy.py
+++ b/python/tests/legs/test_legs_legacy.py
@@ -1492,7 +1492,7 @@ class TestZeroFloatLeg:
                     frequency="Z",
                 ),
                 notional=-1e8,
-                convention="ActAct",
+                convention="ActActISDA",
             )
 
     def test_zero_float_leg_analytic_delta(self, curve) -> None:
@@ -1504,7 +1504,7 @@ class TestZeroFloatLeg:
                 frequency="A",
             ),
             notional=-1e8,
-            convention="ActAct",
+            convention="ActActISDA",
             float_spread=1.0,
             fixing_series=FloatRateSeries(
                 lag=0,
@@ -1578,7 +1578,7 @@ class TestZeroFixedLeg:
                 frequency=freq,
             ),
             notional=-1e8,
-            convention="ActAct",
+            convention="ActActISDA",
             fixed_rate=rate,
         )
         result = zfl.cashflows(disc_curve=curve)
@@ -1611,7 +1611,7 @@ class TestZeroFixedLeg:
                 frequency="A",
             ),
             notional=-1e8,
-            convention="ActAct",
+            convention="ActActISDA",
             fixed_rate=2.0,
         )
         result = zfl.cashflows(disc_curve=curve)
@@ -1639,7 +1639,7 @@ class TestZeroFixedLeg:
                 frequency="A",
             ),
             notional=-1e8,
-            convention="ActAct",
+            convention="ActActISDA",
             fixed_rate=2.5,
         )
         result = zfl.npv(disc_curve=curve)
@@ -1657,7 +1657,7 @@ class TestZeroFixedLeg:
                 frequency="A",
             ),
             notional=-1e8,
-            convention="ActAct",
+            convention="ActActISDA",
             fixed_rate=2.5,
         )
         result2 = zfl.analytic_delta(disc_curve=curve)
@@ -1680,7 +1680,7 @@ class TestZeroFixedLeg:
                 frequency="A",
             ),
             notional=-1e8,
-            convention="ActAct",
+            convention="ActActISDA",
             fixed_rate=NoInput(0),
         )
         result = zfl.spread(
@@ -1702,7 +1702,7 @@ class TestZeroFixedLeg:
                 frequency="M",
             ),
             notional=-1e8,
-            convention="ActAct",
+            convention="ActActISDA",
             final_exchange=final_exchange,
             fixed_rate=NoInput(0),
         )
@@ -1725,7 +1725,7 @@ class TestZeroFixedLeg:
                 frequency="A",
             ),
             notional=-1e8,
-            convention="ActAct",
+            convention="ActActISDA",
             fixed_rate=NoInput(0),
         )
         with pytest.raises(ZeroDivisionError):
@@ -1747,7 +1747,7 @@ class TestZeroFixedLeg:
                 frequency="A",
             ),
             notional=-1e8,
-            convention="ActAct",
+            convention="ActActISDA",
             fixed_rate=NoInput(0),
             final_exchange=final_exchange,
             index_base=100.0,
@@ -1775,7 +1775,7 @@ class TestZeroFixedLeg:
                 frequency="A",
             ),
             notional=-1e8,
-            convention="ActAct",
+            convention="ActActISDA",
             fixed_rate=NoInput(0),
             currency="usd",
             final_exchange=final_exchange,
@@ -1804,7 +1804,7 @@ class TestZeroFixedLeg:
                     frequency="A",
                 ),
                 notional=-1e8,
-                convention="ActAct",
+                convention="ActActISDA",
                 fixed_rate=NoInput(0),
                 amortization=1.0,
             )
@@ -1819,7 +1819,7 @@ class TestZeroFixedLeg:
                     frequency="Z",
                 ),
                 notional=-1e8,
-                convention="ActAct",
+                convention="ActActISDA",
                 fixed_rate=NoInput(0),
             )
 
@@ -1832,7 +1832,7 @@ class TestZeroFixedLeg:
                 frequency="A",
             ),
             notional=-1e8,
-            convention="ActAct",
+            convention="ActActISDA",
             fixed_rate=NoInput(0),
         )
         with pytest.raises(ValueError, match="A `fixed_rate` must be set for a "):

--- a/python/tests/scheduling/test_calendars.py
+++ b/python/tests/scheduling/test_calendars.py
@@ -233,8 +233,8 @@ def test_modifiers_eom(cal_, modifier, expected) -> None:
         (dt(2022, 1, 1), dt(2022, 4, 1), "ACT360", 0.2465753424657534 * 365 / 360),
         (dt(2022, 1, 1), dt(2022, 4, 1), "30360", 0.250),
         (dt(2022, 1, 1), dt(2022, 4, 1), "30E360", 0.250),
-        (dt(2022, 1, 1), dt(2022, 4, 1), "ACTACT", 0.2465753424657534),
-        (dt(2022, 1, 1), dt(2022, 1, 1), "ACTACT", 0.0),
+        (dt(2022, 1, 1), dt(2022, 4, 1), "ACTACTISDA", 0.2465753424657534),
+        (dt(2022, 1, 1), dt(2022, 1, 1), "ACTACTISDA", 0.0),
         (dt(2022, 1, 1), dt(2023, 1, 31), "1+", 1.0),
         (dt(2022, 1, 1), dt(2024, 2, 28), "1+", 2 + 1 / 12),
         (dt(2022, 1, 1), dt(2022, 4, 1), "BUS252", 0.35714285714285715),
@@ -419,6 +419,15 @@ def test_dcf_actacticma_raises():
             True,
             Cal.from_name("tgt"),
             NoInput(0),
+        )
+
+
+def test_dcf_actact_raises():
+    with pytest.raises(ValueError, match=r"`ActAct` must be directly specified as `ActActICMA` "):
+        _ = dcf(
+            dt(2022, 2, 28),
+            dt(2023, 2, 28),
+            "actact",
         )
 
 


### PR DESCRIPTION
(cherry picked from commit c34ce1fc7200a33fe21b79283ee258720b338e8f)